### PR TITLE
added missing development dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,6 +18,7 @@ begin
     gem.test_files = []
     gem.add_development_dependency "rspec"
     gem.add_development_dependency "nokogiri"
+    gem.add_development_dependency "sqlite3-ruby"
   end
   Jeweler::GemcutterTasks.new
 rescue LoadError


### PR DESCRIPTION
I noticed when I was bootstrapping and trying to get the specs to pass, that sqlite3-ruby was a required dependency.
