### PR TITLE
Issue with Rails.root not available in initializers

### DIFF
--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -57,7 +57,7 @@ module SitemapGenerator
       @public_path = public_path
       @sitemaps_path = sitemaps_path
 
-      @public_path = File.join(::Rails.root, 'public/') if @public_path.nil?
+      @public_path = 'public/' if @public_path.nil?
 
       # Default host is not set yet.  Set it on these objects when `add_links` is called
       self.sitemap_index = SitemapGenerator::Builder::SitemapIndexFile.new(@public_path, sitemap_index_path)


### PR DESCRIPTION
I had an issue when trying to boot my server that was raising a "can't convert nil into String" in lib/sitemap_generator/link_set.rb:60

After a google search it appears some other plugins had the exact same issue :

http://support.getexceptional.com/discussions/problems/134-rails3-issues-with-railsroot-being-null
or here:
http://groups.google.com/group/carrierwave/browse_thread/thread/cb623714fdd9ffdf/b9fc254c632bce79?#b9fc254c632bce79

and after a look at how they resolve it here :

http://github.com/contrast/exceptional/commit/4f3297d80094c74325e46fb5f892ec1ef9fac9b1

I applied the same schema. I don't know if it's the best solution or if it breaks other things but it works for me with Rails 3.0.1 + ruby 1.8.7.
