### PR TITLE
Patch to avoid loading 'action_view' on rake startup, thus causing chaos for other rake tasks.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,20 @@ ENV["RAILS_ENV"] ||= 'test'
 # TODO Fix Rails 3
 #ENV['BUNDLE_GEMFILE'] = File.join(File.dirname(__FILE__), 'mock_rails3_gem', 'Gemfile')
 
+module Helpers
+  extend self
+
+  # Invoke and then re-enable the task so it can be called multiple times
+  #
+  # <tt>task</tt> task symbol/string
+  def invoke_task(task)
+    Rake.send(:verbose, false)
+    Rake::Task[task.to_s].invoke
+    Rake::Task[task.to_s].reenable
+  end
+end
+
+
 sitemap_rails =
   case ENV["SITEMAP_RAILS"]
   when 'rails3'
@@ -14,6 +28,7 @@ sitemap_rails =
 
 # Load the app's Rakefile so we know everything is being loaded correctly
 load(File.join(File.dirname(__FILE__), sitemap_rails, 'Rakefile'))
+Helpers.invoke_task('sitemap:environment')
 
 require 'rubygems'
 begin
@@ -34,17 +49,4 @@ Spec::Runner.configure do |config|
   config.mock_with :mocha
   config.include(FileMacros)
   config.include(XmlMacros)
-end
-
-module Helpers
-  extend self
-
-  # Invoke and then re-enable the task so it can be called multiple times
-  #
-  # <tt>task</tt> task symbol/string
-  def invoke_task(task)
-    Rake.send(:verbose, false)
-    Rake::Task[task.to_s].invoke
-    Rake::Task[task.to_s].reenable
-  end
 end

--- a/tasks/sitemap_generator_tasks.rake
+++ b/tasks/sitemap_generator_tasks.rake
@@ -1,26 +1,19 @@
-environment = begin
-
-  # Try to require the library.  If we are installed as a gem, this should work.
-  # We don't need to load the environment.
-  require 'sitemap_generator'
-  []
-
-rescue LoadError
-
-  # We must be installed as a plugin.  Make sure the environment is loaded
-  # when running all rake tasks.
-  [:environment]
-
-end
-
 namespace :sitemap do
+  task :environment do
+    Rake::Task["environment"].invoke
+    begin
+      require 'sitemap_generator'
+    rescue LoadError
+    end
+  end
+
   desc "Install a default config/sitemap.rb file"
-  task :install => environment do
+  task :install => ['sitemap:environment'] do
     SitemapGenerator::Utilities.install_sitemap_rb(verbose)
   end
 
   desc "Delete all Sitemap files in public/ directory"
-  task :clean => environment do
+  task :clean => ['sitemap:environment'] do
     SitemapGenerator::Utilities.clean_files
   end
 


### PR DESCRIPTION
Add a new (internal) rake task, sitemap:environment, to handle the loading of the sitemap_generator gem as well as the rails environment. Always load the rails environment because the documented examples make use of URL helpers which will fail without it, and because requiring 'action_view' in the rakefile before loading the rails environment will cause problems for any other tasks that try to render views.
