### PR TITLE
Fixes absolute path in local filesystem for sitemap files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 SitemapGenerator
 ================
 
+- my fork changes: Fixes absolute path in local filesystem for sitemap files
+
 SitemapGenerator generates Sitemaps for your Rails application.  The Sitemaps adhere to the [Sitemap 0.9 protocol][sitemap_protocol] specification.  You specify the contents of your Sitemap using a configuration file, à la Rails Routes.  A set of rake tasks is included to help you manage your Sitemaps.
 
 Features

--- a/lib/sitemap_generator/builder/sitemap_url.rb
+++ b/lib/sitemap_generator/builder/sitemap_url.rb
@@ -11,7 +11,7 @@ module SitemapGenerator
       def initialize(path, options={})
         if sitemap = path.is_a?(SitemapGenerator::Builder::SitemapFile) && path
           options.reverse_merge!(:host => sitemap.host, :lastmod => sitemap.lastmod)
-          path = sitemap.path
+          path = sitemap.url
         end
 
         SitemapGenerator::Utilities.assert_valid_keys(options, :priority, :changefreq, :lastmod, :host, :images, :video, :geo)


### PR DESCRIPTION
it works, but I'm not sure if this is the correct place to fix it.

The problem was that I ended up with someting like this in sitemap1.xml.gz
http://example.de/Users/durandom/Sites/example/public/sitemaps/sitemap_index.xml.gz
instead of
http://example.de/sitemaps/sitemap_index.xml.gz
