### PR TITLE
Use default adapter option in groups

### DIFF
--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -347,7 +347,8 @@ module SitemapGenerator
         :public_path,
         :sitemaps_host,
         :verbose,
-        :default_host
+        :default_host,
+        :adapter
       ].inject({}) do |hash, key|
         if value = instance_variable_get(:"@#{key}")
           hash[key] = value


### PR DESCRIPTION
Don't lose the adapter default when adding links within a group
