### PR TITLE
Added in AwsAdapert, uploads the sitemap to an s3 using the aws-sdk gem

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -11,6 +11,7 @@ module SitemapGenerator
   autoload(:Interpreter, 'sitemap_generator/interpreter')
   autoload(:FileAdapter, 'sitemap_generator/adapters/file_adapter')
   autoload(:WaveAdapter, 'sitemap_generator/adapters/wave_adapter')
+  autoload(:AwsAdapter,  'sitemap_generator/adapters/aws_adapter')
   autoload(:BigDecimal,  'sitemap_generator/core_ext/big_decimal')
   autoload(:Numeric,     'sitemap_generator/core_ext/numeric')
 

--- a/lib/sitemap_generator/adapters/aws_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_adapter.rb
@@ -1,0 +1,34 @@
+require 'aws-sdk'
+
+module SitemapGenerator
+  class AwsAdapter
+    # Call with a SitemapLocation and string data
+    def write(location, raw_data)
+      # Check to see if s3.yml exists
+      begin
+        s3config = YAML::load(File.open("#{Rails.root}/config/s3.yml"))
+      rescue
+        e.message << " (s3.yml is missing)"
+        raise e
+      end
+      # Check to make sure keys are good.
+      begin
+        s3 = AWS::S3.new(
+        :access_key_id     => s3config[Rails.env.to_s]["access_key_id"],
+        :secret_access_key => s3config[Rails.env.to_s]["secret_access_key"]
+        )
+        bucket = s3.buckets[s3config[Rails.env.to_s]["bucket"]]
+      rescue
+        e.message << "Failed To Connct to S3"
+        raise e
+      end
+
+      file = SitemapGenerator::FileAdapter.new.write(location, raw_data)
+      filename = file.path.split("/").last
+      obj = bucket.objects[SitemapGenerator::Sitemap.sitemaps_path + filename]
+      content = File.read(file.path)
+      obj.write(content)
+      obj.acl=:public_read
+    end
+  end
+end


### PR DESCRIPTION
I am working on a project that uses paperclip and aws-sdk, so I didn't want to install carrierwave. I saw that you had made a rake task that does this, but I thought for ease of use I might as well create an adapter.

Requirements
aws-sdk gem
Requires an config/s3.yml file. Set up the same way paperclip does.

The config is just about the same

``` ruby
SitemapGenerator::Sitemap.default_host = "http://www.example.com/"
SitemapGenerator::Sitemap.sitemaps_host = "http://s3.amazonaws.com/bucketnamehere/"
SitemapGenerator::Sitemap.public_path = 'tmp/'
SitemapGenerator::Sitemap.sitemaps_path = 'sitemaps/'
SitemapGenerator::Sitemap.adapter = SitemapGenerator::AwsAdapter.new
SitemapGenerator::Sitemap.create do
  #your set up here
end
```

I hope this helps!
