### PR TITLE
Update lib/sitemap_generator/builder/sitemap_file.rb

### DIFF
--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -34,7 +34,7 @@ module SitemapGenerator
               xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
               xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"
               xmlns:geo="http://www.google.com/geo/schemas/sitemap/1.0"
-              xmlns:news="http://www.google.com/schemas/sitemap-news/0.9/"
+              xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
               xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
             >
         HTML


### PR DESCRIPTION
Remove trailing slash of xml namespace news url.  
It raises a warning with Google Webmaster:

Warning:
Incorrect namespace
Your Sitemap or Sitemap index file doesn't properly declare the namespace.
Expected: http://www.google.com/schemas/sitemap-news/0.9 
Found: http://www.google.com/schemas/sitemap-news/0.9/
