### PR TITLE
Update lib/sitemap_generator/adapters/s3_adapter.rb

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -18,7 +18,7 @@ module SitemapGenerator
       directory.files.create(
         :key    => location.path_in_public, 
         :body   => File.open(location.path),
-        :public => true,
+        :public => true
       )
     end
   end


### PR DESCRIPTION
Removed the "comma" that's not compatible with Ruby 1.8.7

(Question: Are there any other parts of the gem not compatible with Ruby 1.8.7?)
