### PR TITLE
Configurable settings for S3Adapter

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -3,23 +3,31 @@ require 'fog'
 module SitemapGenerator
   class S3Adapter
 
+    def initialize(opts = {})
+      @aws_access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
+      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
+      @fog_provider = opts[:fog_provider] || ENV['FOG_PROVIDER']
+      @fog_directory = opts[:fog_directory] || ENV['FOG_DIRECTORY']
+    end
+
     # Call with a SitemapLocation and string data
     def write(location, raw_data)
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
-      
+
       credentials = { 
-        :aws_access_key_id     => ENV['AWS_ACCESS_KEY_ID'],
-        :aws_secret_access_key => ENV['AWS_SECRET_ACCESS_KEY'],
-        :provider              => ENV['FOG_PROVIDER'],
+        :aws_access_key_id     => @aws_access_key_id,
+        :aws_secret_access_key => @aws_secret_access_key,
+        :provider              => @fog_provider,
       }
-      
+
       storage   = Fog::Storage.new(credentials)
-      directory = storage.directories.get(ENV['FOG_DIRECTORY'])
+      directory = storage.directories.get(@fog_directory)
       directory.files.create(
-        :key    => location.path_in_public, 
+        :key    => location.path_in_public,
         :body   => File.open(location.path),
         :public => true
       )
     end
+
   end
 end


### PR DESCRIPTION
The S3 adapter works pretty well, but it can only use very specific configuration variables from Heroku. This change allows devs to configure different settings at will.
