### PR TITLE
Add `only` and `exclude` options to conditionally generate groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Does your website use SitemapGenerator to generate Sitemaps?  Where would you be
 
 ## Changelog
 
+* v3.4.1: Support `exclude` and `only` options options to conditionally skip processing of groups.
 * v3.4: Support [alternate links][alternate_links] for urls; Support configurable options in the `SitemapGenerator::S3Adapter`
 * v3.3: **Support creating sitemaps with no index file**.  A big thank-you to [Eric Hochberger][ehoch] for generously paying for this feature.
 * v3.2.1: Fix syntax error in SitemapGenerator::S3Adapter
@@ -642,11 +643,15 @@ The following options are supported:
 
 * `default_host` - String.  Required.  **Host including protocol** to use when building a link to add to your sitemap.  For example `http://example.com`.  Calling `add '/home'` would then generate the URL `http://example.com/home` and add that to the sitemap.  You can pass a `:host` option in your call to `add` to override this value on a per-link basis.  For example calling `add '/home', :host => 'https://example.com'` would generate the URL `https://example.com/home`, for that link only.
 
+* `exclude` - String.  A CSV string whose elements are converted to Regex.  Skips processing of any group whose `:filename` matches against at least 1 Regex element.  Superceded by `only` option if a `:filename` matches both conditions.
+
 * `filename` - Symbol.  The **base name for the files** that will be generated.  The default value is `:sitemap`.  This yields sitemaps with names like `sitemap1.xml.gz`, `sitemap2.xml.gz`, `sitemap3.xml.gz` etc, and a sitemap index named `sitemap_index.xml.gz`.  If we now set the value to `:geo` the sitemaps would be named `geo1.xml.gz`, `geo2.xml.gz`, `geo3.xml.gz` etc, and the sitemap index would be named `geo_index.xml.gz`.
 
 * `include_index` - Boolean.  Whether to **add a link to the sitemap index** to the current sitemap.  This points search engines to your Sitemap Index to include it in the indexing of your site.  2012-07: This is now turned off by default because Google may complain about there being 'Nested Sitemap indexes'.  Default is `false`.  Turned off when `sitemaps_host` is set or within a `group()` block.
 
 * `include_root` - Boolean.  Whether to **add the root** url i.e. '/' to the current sitemap.  Default is `true`.  Turned off within a `group()` block.
+
+* `only` - String.  A CSV string whose elements are converted to Regex.  Skips processing of any group whose `:filename` does not match any Regex element.  Overrides `exclude` condition if `:filename` matches both conditions.
 
 * `public_path` - String.  A **full or relative path** to the `public` directory or the directory you want to write sitemaps into.  Defaults to `public/` under your application root or relative to the current working directory.
 

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -42,7 +42,7 @@ module SitemapGenerator
 
   class << self
     attr_accessor :root, :app, :templates
-    attr_writer :yield_sitemap, :verbose
+    attr_writer :exclude, :only, :yield_sitemap, :verbose
   end
 
   # Global default for the verbose setting.
@@ -57,6 +57,34 @@ module SitemapGenerator
       end
     else
       @verbose
+    end
+  end
+
+  # List of group names to be run.  Can be given an Array or a CSV String.
+  # Values converted to Regex
+  def self.only
+    if @only.nil?
+      @only = if ENV['ONLY'].is_a?(String)
+        ENV['ONLY'].split(',').map {|filname| Regexp.new(filname)}
+      else
+        []
+      end
+    else
+      @only
+    end
+  end
+
+  # List of excluded group names.  Can be given an Array or a CSV String
+  # Values converted to Regex.
+  def self.exclude
+    if @exclude.nil?
+      @exclude = if ENV['EXCLUDE'].is_a?(String)
+        ENV['EXCLUDE'].split(',').map {|filname| Regexp.new(filname)}
+      else
+        []
+      end
+    else
+      @exclude
     end
   end
 

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -165,6 +165,28 @@ describe SitemapGenerator::LinkSet do
     end
   end
 
+  describe "only" do
+    it "should be set as an initialize option" do
+      SitemapGenerator::LinkSet.new(:default_host => default_host, :only => [/group_name/]).only.should == [/group_name/]
+    end
+
+    it "should be set as an accessor" do
+      ls.only = [/group_name/]
+      ls.only.should == [/group_name/]
+    end
+  end
+
+  describe "exclude" do
+    it "should be set as an initialize option" do
+      SitemapGenerator::LinkSet.new(:default_host => default_host, :exclude => [/group_name/]).exclude.should == [/group_name/]
+    end
+
+    it "should be set as an accessor" do
+      ls.exclude = [/group_name/]
+      ls.exclude.should == [/group_name/]
+    end
+  end
+
   describe "verbose" do
     it "should be set as an initialize option" do
       SitemapGenerator::LinkSet.new(:default_host => default_host, :verbose => false).verbose.should be_false
@@ -478,6 +500,16 @@ describe SitemapGenerator::LinkSet do
       ls.create(:filename => :xxx)
       ls.filename.should == :xxx
       ls.sitemap.location.filename.should =~ /xxx/
+    end
+
+    it "should set only" do
+      ls.create(:only => [/set_group_name_only/])
+      ls.only.should == [/set_group_name_only/]
+    end
+
+    it "should set exclude" do
+      ls.create(:exclude => [/set_group_name_exclude/])
+      ls.exclude.should == [/set_group_name_exclude/]
     end
 
     it "should set verbose" do

--- a/spec/sitemap_generator/sitemap_generator_spec.rb
+++ b/spec/sitemap_generator/sitemap_generator_spec.rb
@@ -179,6 +179,44 @@ describe "SitemapGenerator" do
     end
   end
 
+  describe "exclude" do
+    before(:each) { ENV['EXCLUDE'] = SitemapGenerator.exclude = nil }
+    after(:all)   { ENV['EXCLUDE'] = SitemapGenerator.exclude = nil }
+
+    it "should be set via ENV['EXCLUDE']" do
+      ENV['EXCLUDE'] = 'group_name'
+      SitemapGenerator.exclude.should == [/group_name/]
+    end
+
+    it "should set SitemapGenerator.exclude to an empty array if given not set" do
+      SitemapGenerator.exclude.should == []
+    end
+
+    it "should split on ',' and convert elements to Regex when given a String" do
+      ENV['EXCLUDE'] = 'exclude_group_name1,exclude_group_name2'
+      SitemapGenerator.exclude.should == [/exclude_group_name1/,/exclude_group_name2/]
+    end
+  end
+
+  describe "only" do
+    before(:each) { ENV['ONLY'] = SitemapGenerator.only = nil }
+    after(:all)   { ENV['ONLY'] = SitemapGenerator.only = nil }
+
+    it "should be set via ENV['ONLY']" do
+      ENV['ONLY'] = 'group_name'
+      SitemapGenerator.only.should == [/group_name/]
+    end
+
+    it "should set SitemapGenerator.only to an empty array if given not set" do
+      SitemapGenerator.only.should == []
+    end
+
+    it "should split on ',' and convert elements to Regex when given a String" do
+      ENV['ONLY'] = 'only_group_name1,only_group_name2'
+      SitemapGenerator.only.should == [/only_group_name1/,/only_group_name2/]
+    end
+  end
+
   describe "verbose" do
     it "should be set via ENV['VERBOSE']" do
       original = SitemapGenerator.verbose


### PR DESCRIPTION
Hello,

This is my first open source contribution so if I missed anything please let me know and I'd be happy to correct it.

This commit comes from my use case where certain `group`s in my sitemap.rb take hours to run, even longer in development.  This made testing sitemap generation an issue.

In many cases I would want to run everything but the very slow groups.  In some cases I would want to test run only the groups I modified.  My workaround was to comment out unwanted groups but since my sitemap.rb was several hundred lines it became cumbersome.

My solution is to add rake task options so that only the groups I want generated get run e.g.

`rake sitemap:refresh:no_ping EXCLUDE=very_slow_group` to skip the long running groups.  

Or

 `rake sitemap:refresh:no_ping ONLY=newly_modified_group` to only run modified groups.

Groups that are skipped are printed like:

`! group "very_slow_group" not processed - not included in ONLY option`

and

`! group "very_slow_group" not processed - not included in EXCLUDE option`

respectively.

My implementation was to essentially piggyback off the `VERBOSE` option definition.

Thank you and I appreciate any feedback you can give me.

-Chris Holaday
