### PR TITLE
Remove rcov in ruby1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :development, :test do
   gem 'mocha'
   gem 'nokogiri'
   gem 'rake'
-  gem 'rcov'
+  gem 'rcov' if RUBY_VERSION < '1.9'
   gem 'rspec'
   # gem 'ruby-debug19', :require => 'ruby-debug'
 end


### PR DESCRIPTION
rcov does not work on ruby1.9
https://github.com/relevance/rcov
