### PR TITLE
added rake task for ping-only

### DIFF
--- a/lib/sitemap_generator/tasks.rb
+++ b/lib/sitemap_generator/tasks.rb
@@ -50,4 +50,9 @@ namespace :sitemap do
   task :create => ['sitemap:require_environment'] do
     SitemapGenerator::Interpreter.run(:config_file => ENV["CONFIG_FILE"], :verbose => verbose)
   end
+
+  desc "Ping search engines but don't generate sitemaps."
+  task :ping do
+    SitemapGenerator::Sitemap.ping_search_engines
+  end
 end


### PR DESCRIPTION
I've added a rake task for just performing search engine pings (`rake sitemap:ping`). This is particularly useful in multi-server environments where each server needs to generate the sitemaps, but the search engines only need to be pinged once. 
