### PR TITLE
Remove Sitemap Writer

### DIFF
--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -124,8 +124,7 @@ module SitemapGenerator
         :filename => :sitemap,
         :search_engines => {
           :google         => "http://www.google.com/webmasters/tools/ping?sitemap=%s",
-          :bing           => "http://www.bing.com/webmaster/ping.aspx?siteMap=%s",
-          :sitemap_writer => "http://www.sitemapwriter.com/notify.php?crawler=all&url=%s"
+          :bing           => "http://www.bing.com/webmaster/ping.aspx?siteMap=%s"
         },
         :create_index => :auto
       )


### PR DESCRIPTION
According to the [Sitemap Writer website](http://www.sitemapwriter.com/notify.php), it updates "Google, Ask.com and Bing (Live.com)". Since Ask no longer accepts sitemaps, this service is redundant?
