### PR TITLE
expose fog_path_style configuration

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -13,6 +13,7 @@ module SitemapGenerator
       @fog_provider = opts[:fog_provider] || ENV['FOG_PROVIDER']
       @fog_directory = opts[:fog_directory] || ENV['FOG_DIRECTORY']
       @fog_region = opts[:fog_region] || ENV['FOG_REGION']
+      @fog_path_style = opts[:fog_path_style]
     end
 
     # Call with a SitemapLocation and string data
@@ -25,6 +26,7 @@ module SitemapGenerator
         :provider              => @fog_provider,
       }
       credentials[:region] = @fog_region if @fog_region
+      credentials[:path_style] = @fog_path_style if @fog_path_style
 
       storage   = Fog::Storage.new(credentials)
       directory = storage.directories.new(:key => @fog_directory)


### PR DESCRIPTION
setting path_style to true is necessary to make bucket with dots in the
name work on https and avoid ssl certificate problems
