### PR TITLE
Add FogAdapter

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -12,6 +12,7 @@ module SitemapGenerator
   autoload(:FileAdapter, 'sitemap_generator/adapters/file_adapter')
   autoload(:S3Adapter,   'sitemap_generator/adapters/s3_adapter')
   autoload(:WaveAdapter, 'sitemap_generator/adapters/wave_adapter')
+  autoload(:FogAdapter,  'sitemap_generator/adapters/fog_adapter')
   autoload(:BigDecimal,  'sitemap_generator/core_ext/big_decimal')
   autoload(:Numeric,     'sitemap_generator/core_ext/numeric')
 

--- a/lib/sitemap_generator/adapters/fog_adapter.rb
+++ b/lib/sitemap_generator/adapters/fog_adapter.rb
@@ -1,0 +1,31 @@
+begin
+  require 'fog'
+rescue LoadError
+  raise LoadError.new("Missing required 'fog'.  Please 'gem install fog' and require it in your application.")
+end
+
+module SitemapGenerator
+  class FogAdapter
+
+    def initialize(opts = {})
+      @fog_credentials = opts[:fog_credentials]
+      @fog_directory = opts[:fog_directory]
+    end
+
+    # Call with a SitemapLocation and string data
+    def write(location, raw_data)
+      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+
+      storage   = Fog::Storage.new(@fog_credentials)
+      directory = storage.directories.new(:key => @fog_directory)
+      directory.files.create(
+        :key    => location.path_in_public,
+        :body   => File.open(location.path),
+        :public => true
+      )
+
+      File.delete(location.path)
+    end
+
+  end
+end


### PR DESCRIPTION
`FogAdapter` is based on `S3Adapter`, just more flexible and can be easily used with RackSpace or other CDNs supported by `Fog`. No need for `CarrierWave` which used `Fog` itself.
