### PR TITLE
Fix Capistrano Tasks to Use Stage

### DIFF
--- a/lib/capistrano/tasks/sitemap_generator.cap
+++ b/lib/capistrano/tasks/sitemap_generator.cap
@@ -4,7 +4,7 @@ namespace :deploy do
     task :refresh do
       on roles :web do
         within release_path do
-          with rails_env: fetch(:rails_env) do
+          with rails_env: (fetch(:rails_env) || fetch(:stage)) do
            execute :rake, "sitemap:refresh"
           end
         end
@@ -15,7 +15,7 @@ namespace :deploy do
     task :create do
       on roles :web do
         within release_path do
-          with rails_env: fetch(:rails_env) do
+          with rails_env: (fetch(:rails_env) || fetch(:stage)) do
            execute :rake, "sitemap:create"
           end
         end
@@ -26,7 +26,7 @@ namespace :deploy do
     task :clean do
       on roles :web do
         within release_path do
-          with rails_env: fetch(:rails_env) do
+          with rails_env: (fetch(:rails_env) || fetch(:stage)) do
            execute :rake, "sitemap:clean"
           end
         end


### PR DESCRIPTION
This pull request references issue #163 where capistrano tasks fail to create sitemaps because it cannot determine the environment. It seems that capistrano 3 uses stages to determine the RAILS_ENV in addition to what the environment is. I added code identical to how Capistrano itself determines its environment: https://github.com/capistrano/rails/blob/master/lib/capistrano/tasks/set_rails_env.rake

I tested the change on my setup which uses Capistrano 3 and the master branch of sitemap_generator and this seems to correct the problem.
