### PR TITLE
Implement respond_to? in SitemapGenerator::Sitemap

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -42,6 +42,10 @@ module SitemapGenerator
         (@link_set ||= reset!).send(*args, &block)
       end
 
+      def respond_to?(name, include_private = false)
+        (@link_set ||= reset!).respond_to?(name, include_private)
+      end
+
       # Use a new LinkSet instance
       def reset!
         @link_set = LinkSet.new


### PR DESCRIPTION
`SitemapGenerator::Sitemap` implementation is based on `method_missing`, but it didn't have proper `respond_to?` implementation. 

For this reason, e.g., it didn't play well with RSpec mocking with `verify_partial_doubles = true`.