### PR TITLE
Supports AWS IAM profile

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -21,11 +21,15 @@ module SitemapGenerator
     def write(location, raw_data)
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
 
-      credentials = {
-        :aws_access_key_id     => @aws_access_key_id,
-        :aws_secret_access_key => @aws_secret_access_key,
-        :provider              => @fog_provider,
-      }
+      credentials = { :provider => @fog_provider }
+
+      if @aws_access_key_id && @aws_secret_access_key
+        credentials[:aws_access_key_id] = @aws_access_key_id
+        credentials[:aws_secret_access_key] = @aws_secret_access_key
+      else
+        credentials[:use_iam_profile] = true
+      end
+
       credentials[:region] = @fog_region if @fog_region
       credentials[:path_style] = @fog_path_style if @fog_path_style
 


### PR DESCRIPTION
Using IAM instance role profile instead of setting access key & secret is recommended by AWS as security best practice.