### PR TITLE
Require 'fog/storage' rather than 'fog'

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -1,5 +1,5 @@
 begin
-  require 'fog'
+  require 'fog/storage'
 rescue LoadError
   raise LoadError.new("Missing required 'fog'.  Please 'gem install fog' and require it in your application.")
 end


### PR DESCRIPTION
This makes it possible to use the fog-aws gem to allow sitemaps to be
uploaded to s3, rather than using the root fog gem. fog-aws has far
fewer dependencies than the fog gem itself so is the preferred option in
projects that don't already have fog as a dependency.