### PR TITLE
remove additional line in xsi:schemaLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ Now let's take a look at the file that was created.  After uncompressing and XML
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:geo="http://www.google.com/geo/schemas/sitemap/1.0" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:geo="http://www.google.com/geo/schemas/sitemap/1.0" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <url>
     <loc>http://www.example.com/</loc>
     <lastmod>2011-05-21T00:03:38+00:00</lastmod>
@@ -577,7 +577,7 @@ Now if we look at the uncompressed and formatted contents of `sitemap.xml.gz` we
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">
+<sitemapindex xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd">
   <sitemap>
     <loc>http://www.example.com/sitemap1.xml.gz</loc>
     <lastmod>2013-05-01T18:10:26-07:00</lastmod>

--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -28,8 +28,7 @@ module SitemapGenerator
           <?xml version="1.0" encoding="UTF-8"?>
             <urlset
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-                http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
               xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
               xmlns:image="#{SitemapGenerator::SCHEMAS['image']}"
               xmlns:video="#{SitemapGenerator::SCHEMAS['video']}"

--- a/lib/sitemap_generator/builder/sitemap_index_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_index_file.rb
@@ -15,8 +15,7 @@ module SitemapGenerator
           <?xml version="1.0" encoding="UTF-8"?>
             <sitemapindex
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-                http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
+              xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9/siteindex.xsd"
               xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
             >
         HTML


### PR DESCRIPTION
After some Googling, I see that most examples of `xsi:schemaLocation` just go to an .xsd file, without an additional URL before it. This PR removes that additional URL.