### PR TITLE
use create instead of new for bucket creation / recognition

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -34,7 +34,7 @@ module SitemapGenerator
       credentials[:path_style] = @fog_path_style if @fog_path_style
 
       storage   = Fog::Storage.new(@fog_storage_options.merge(credentials))
-      directory = storage.directories.new(:key => @fog_directory)
+      directory = storage.directories.create(:key => @fog_directory)
       directory.files.create(
         :key    => location.path_in_public,
         :body   => File.open(location.path),

--- a/spec/sitemap_generator/adapters/s3_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/s3_adapter_spec.rb
@@ -10,7 +10,7 @@ describe 'SitemapGenerator::S3Adapter', :integration => true do
 
   let(:location) { SitemapGenerator::SitemapLocation.new(:namer => SitemapGenerator::SitemapNamer.new(:sitemap), :public_path => 'tmp/', :sitemaps_path => 'test/', :host => 'http://example.com/') }
   let(:directory) { stub(:files => stub(:create)) }
-  let(:directories) { stub(:directories => stub(:new => directory)) }
+  let(:directories) { stub(:directories => stub(:create => directory)) }
 
   before do
     SitemapGenerator::S3Adapter # eager load


### PR DESCRIPTION
change fog directive to use `create` instead of `new` on bucket so custom specs with `Fog.mock!` can pass as they require a directive to create the bucket first.