### PR TITLE
Load the rake task instead of requiring them

### DIFF
--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -1,7 +1,7 @@
 module SitemapGenerator
   class Railtie < Rails::Railtie
     rake_tasks do
-      require File.expand_path('../tasks', __FILE__)
+      load "tasks/sitemap_generator_tasks.rake"
     end
   end
 end


### PR DESCRIPTION
Reason for the change:
I am trying to run `Rake::Task["sitemap:refresh"]` from a resque background job. But I get `RuntimeError Don't know how to build task 'sitemap:refresh'`

Based on http://edgeapi.rubyonrails.org/classes/Rails/Railtie.html#class-Rails::Railtie-label-Loading+rake+tasks+and+generators