### PR TITLE
AWS S3 adapter using the bare aws-sdk gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,10 @@ _This section needs better documentation.  Please consider contributing._
 
   Uses `fog-aws` to upload to Amazon S3 storage.
 
+* `SitemapGenerator::AwsSdkAdapter`
+
+  Uses `aws-sdk` to upload to Amazon S3 storage.
+
 * `SitemapGenerator::WaveAdapter`
 
   Uses `carrierwave` to upload to any service supported by CarrierWave.

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -8,13 +8,14 @@ require 'sitemap_generator/adapters'
 require 'sitemap_generator/sitemap_location'
 
 module SitemapGenerator
-  autoload(:Interpreter, 'sitemap_generator/interpreter')
-  autoload(:FileAdapter, 'sitemap_generator/adapters/file_adapter')
-  autoload(:S3Adapter,   'sitemap_generator/adapters/s3_adapter')
-  autoload(:WaveAdapter, 'sitemap_generator/adapters/wave_adapter')
-  autoload(:FogAdapter,  'sitemap_generator/adapters/fog_adapter')
-  autoload(:BigDecimal,  'sitemap_generator/core_ext/big_decimal')
-  autoload(:Numeric,     'sitemap_generator/core_ext/numeric')
+  autoload(:Interpreter,   'sitemap_generator/interpreter')
+  autoload(:FileAdapter,   'sitemap_generator/adapters/file_adapter')
+  autoload(:S3Adapter,     'sitemap_generator/adapters/s3_adapter')
+  autoload(:AwsSdkAdapter, 'sitemap_generator/adapters/aws_sdk_adapter')
+  autoload(:WaveAdapter,   'sitemap_generator/adapters/wave_adapter')
+  autoload(:FogAdapter,    'sitemap_generator/adapters/fog_adapter')
+  autoload(:BigDecimal,    'sitemap_generator/core_ext/big_decimal')
+  autoload(:Numeric,       'sitemap_generator/core_ext/numeric')
 
   SitemapError          = Class.new(StandardError)
   SitemapFullError      = Class.new(SitemapError)

--- a/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
@@ -1,0 +1,45 @@
+begin
+  require 'aws-sdk'
+rescue LoadError
+  raise LoadError.new("Missing required 'aws-sdk'.  Please 'gem install "\
+                      "aws-sdk' and require it in your application, or "\
+                      "add: gem 'aws-sdk' to your Gemfile.")
+end
+
+module SitemapGenerator
+  # Class for uploading the sitemaps to an S3 bucket using the plain AWS SDK gem
+  class AwsSdkAdapter
+    # @param [String] bucket name of the S3 bucket
+    # @param [Hash]   opts   alternate means of configuration other than ENV
+    # @option opts  [String] :aws_access_key_id instead of ENV['AWS_ACCESS_KEY_ID']
+    # @option opts  [String] :aws_region instead of ENV['AWS_REGION']
+    # @option opts  [String] :aws_secret_access_key instead of ENV['AWS_SECRET_ACCESS_KEY']
+    # @option opts  [String] :path use this prefix on the object key instead of 'sitemaps/'
+    def initialize(bucket, opts = {})
+      @bucket = bucket
+
+      @aws_access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
+      @aws_region = opts[:aws_region] || ENV['AWS_REGION']
+      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
+
+      @path = opts[:path] || 'sitemaps/'
+    end
+
+    # Call with a SitemapLocation and string data
+    def write(location, raw_data)
+      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+
+      credentials = Aws::Credentials.new(@aws_access_key_id, @aws_secret_access_key)
+      s3 = Aws::S3::Resource.new(credentials: credentials, region: @aws_region)
+
+      s3_object_key = "#{@path}#{location.path_in_public}"
+      s3_object = s3.bucket(@bucket).object(s3_object_key)
+
+      content_type = location[:compress] ? 'application/x-gzip' : 'application/xml'
+      s3_object.upload_file(location.path,
+                            acl: 'public-read',
+                            cache_control: 'private, max-age=0, no-cache',
+                            content_type: content_type)
+    end
+  end
+end


### PR DESCRIPTION
An alternate adapter to the S3Adapter for those using the plain old
bare 'aws-sdk' gem without 'fog'. This class modelled on that adapter
but also sets up the S3 object to return the following additional HTTP
headers:

* Cache-Control: private, max-age=0, no-cache
* Content-Type: application/x-gzip

for completeness.

No integration test created, as noted in the s3_adapter_spec.rb, it
would be of limited use.

IAM authentication is not yet supported.