### PR TITLE
Change `rails?` method to check railtie instead rails module

### DIFF
--- a/lib/sitemap_generator/application.rb
+++ b/lib/sitemap_generator/application.rb
@@ -3,7 +3,7 @@ require 'pathname'
 module SitemapGenerator
   class Application
     def rails?
-      defined?(Rails)
+      defined?(Rails::Railtie)
     end
 
     # Returns a boolean indicating whether this environment is Rails 3

--- a/spec/sitemap_generator/application_spec.rb
+++ b/spec/sitemap_generator/application_spec.rb
@@ -3,7 +3,8 @@ require 'spec_helper'
 describe SitemapGenerator::Application do
   before :all do
     SitemapGenerator::Utilities.with_warnings(nil) do
-      Object.const_set(:Rails, Object.new)
+      Object.const_set(:Rails, Object)
+      Object::Rails.const_set(:Railtie, Object)
     end
   end
 


### PR DESCRIPTION
When some non rails project depends on actionmailer, the rails-sanitizer-html gem is loaded and the Rails module is created, this way to check Rails module is not a good idea...

Take a look this issue rails/rails-html-sanitizer#25

A way to solve this is to check for specific methods instead Rails module or Railtie...
