### PR TITLE
Require fog/storage instead of fog in fog adapter

### DIFF
--- a/lib/sitemap_generator/adapters/fog_adapter.rb
+++ b/lib/sitemap_generator/adapters/fog_adapter.rb
@@ -1,7 +1,7 @@
 begin
-  require 'fog'
+  require 'fog/storage'
 rescue LoadError
-  raise LoadError.new("Missing required 'fog'.  Please 'gem install fog' and require it in your application.")
+  raise LoadError.new("Missing required 'fog' or fog provider gem (e.g. 'fog-rackspace').  Please 'gem install fog' and require it in your application.")
 end
 
 module SitemapGenerator


### PR DESCRIPTION
Hey,

Looks like S3 adapter already does this and fog adapter was left out.
Is there anything else missing here? 😄 