### PR TITLE
Use Sitemap namespace for Capistrano

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,9 +310,9 @@ require 'capistrano/sitemap_generator'
 Available capistrano tasks:
 
 ```ruby
-deploy:sitemap:create   #Create sitemaps without pinging search engines
-deploy:sitemap:refresh  #Create sitemaps and ping search engines
-deploy:sitemap:clean    #Clean up sitemaps in the sitemap path
+sitemap:create   #Create sitemaps without pinging search engines
+sitemap:refresh  #Create sitemaps and ping search engines
+sitemap:clean    #Clean up sitemaps in the sitemap path
 ```
 
   **Generate sitemaps into a directory which is shared by all deployments.**

--- a/lib/capistrano/tasks/sitemap_generator.cap
+++ b/lib/capistrano/tasks/sitemap_generator.cap
@@ -1,34 +1,32 @@
-namespace :deploy do
-  namespace :sitemap do
-    desc 'Create sitemap and ping search engines'
-    task :refresh do
-      on roles :web do
-        within release_path do
-          with rails_env: (fetch(:rails_env) || fetch(:stage)) do
-           execute :rake, "sitemap:refresh"
-          end
+namespace :sitemap do
+  desc 'Create sitemap and ping search engines'
+  task :refresh do
+    on roles :web do
+      within release_path do
+        with rails_env: (fetch(:rails_env) || fetch(:stage)) do
+         execute :rake, "sitemap:refresh"
         end
       end
     end
+  end
 
-    desc 'Create sitemap without pinging search engines'
-    task :create do
-      on roles :web do
-        within release_path do
-          with rails_env: (fetch(:rails_env) || fetch(:stage)) do
-           execute :rake, "sitemap:create"
-          end
+  desc 'Create sitemap without pinging search engines'
+  task :create do
+    on roles :web do
+      within release_path do
+        with rails_env: (fetch(:rails_env) || fetch(:stage)) do
+         execute :rake, "sitemap:create"
         end
       end
     end
+  end
 
-    desc 'Clean up sitemaps in sitemap_generator path'
-    task :clean do
-      on roles :web do
-        within release_path do
-          with rails_env: (fetch(:rails_env) || fetch(:stage)) do
-           execute :rake, "sitemap:clean"
-          end
+  desc 'Clean up sitemaps in sitemap_generator path'
+  task :clean do
+    on roles :web do
+      within release_path do
+        with rails_env: (fetch(:rails_env) || fetch(:stage)) do
+         execute :rake, "sitemap:clean"
         end
       end
     end


### PR DESCRIPTION
Since the task `deploy` is quite exclusive to Capistrano, we should use Sitemap Generator's own namespace instead, so not to be confused with Capistrano's `deploy`.
