### PR TITLE
use tempfile when saving to s3

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -15,6 +15,7 @@ module SitemapGenerator
       @fog_region = opts[:fog_region] || ENV['FOG_REGION']
       @fog_path_style = opts[:fog_path_style] || ENV['FOG_PATH_STYLE']
       @fog_storage_options = opts[:fog_storage_options] || {}
+      @fog_key_prefix = opts[:fog_key_prefix] || ""
     end
 
     # Call with a SitemapLocation and string data
@@ -48,8 +49,10 @@ module SitemapGenerator
 
       storage   = Fog::Storage.new(@fog_storage_options.merge(credentials))
       directory = storage.directories.new(:key => @fog_directory)
+
+      key = [@fog_key_prefix, location.path_in_public].join
       directory.files.create(
-        :key    => location.path_in_public,
+        :key    => key, 
         :body   => File.open(temp_file.path),
         :public => true
       )

--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -19,7 +19,20 @@ module SitemapGenerator
 
     # Call with a SitemapLocation and string data
     def write(location, raw_data)
-      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+
+      # write to a temporary file
+      file_name = File.basename(location.path)
+      temp_file = Tempfile.new(file_name.split('.', 2))
+
+      if location.path.to_s =~ /.gz$/
+        temp_file.binmode
+        gz = Zlib::GzipWriter.new(temp_file)
+        gz.write raw_data
+        gz.close
+      else
+        temp_file.write raw_data
+        temp_file.close
+      end
 
       credentials = { :provider => @fog_provider }
 
@@ -37,9 +50,11 @@ module SitemapGenerator
       directory = storage.directories.new(:key => @fog_directory)
       directory.files.create(
         :key    => location.path_in_public,
-        :body   => File.open(location.path),
+        :body   => File.open(temp_file.path),
         :public => true
       )
+      # delete the temporary file
+      temp_file.unlink
     end
 
   end


### PR DESCRIPTION
Using a tempfile instead of the FileAdapter resolves two issues.
- Using the FileAdapter meant that the same file name was used for
  every sitemap. This breaks workers.
- The sitemap file was always written to the "public" directory when
  uploading to s3, now this is no longer the case.
