### PR TITLE
ensure host ends in a slash

### DIFF
--- a/lib/sitemap_generator/sitemap_location.rb
+++ b/lib/sitemap_generator/sitemap_location.rb
@@ -9,16 +9,27 @@ module SitemapGenerator
 
     PATH_OUTPUT_WIDTH = 47 # Character width of the path in the summary lines
 
-    [:host, :adapter].each do |method|
-      define_method(method) do
-        raise SitemapGenerator::SitemapError, "No value set for #{method}" unless self[method]
-        self[method]
-      end
+    def assert_value(key)
+      raise SitemapGenerator::SitemapError, "No value set for #{key}" unless self[key]
+    end
+
+    def assert_slash(key)
+      SitemapGenerator::Utilities.append_slash(self[key])
+    end
+
+    def adapter
+      assert_value(:adapter)
+      self[:adapter]
+    end
+
+    def host
+      assert_value(:host)
+      assert_slash(:host)
     end
 
     [:public_path, :sitemaps_path].each do |method|
       define_method(method) do
-        Pathname.new(SitemapGenerator::Utilities.append_slash(self[method]))
+        Pathname.new(assert_slash(method))
       end
     end
 

--- a/lib/sitemap_generator/sitemap_location.rb
+++ b/lib/sitemap_generator/sitemap_location.rb
@@ -13,7 +13,7 @@ module SitemapGenerator
       raise SitemapGenerator::SitemapError, "No value set for #{key}" unless self[key]
     end
 
-    def assert_slash(key)
+    def append_slash(key)
       SitemapGenerator::Utilities.append_slash(self[key])
     end
 
@@ -24,12 +24,12 @@ module SitemapGenerator
 
     def host
       assert_value(:host)
-      assert_slash(:host)
+      append_slash(:host)
     end
 
     [:public_path, :sitemaps_path].each do |method|
       define_method(method) do
-        Pathname.new(assert_slash(method))
+        Pathname.new(append_slash(method))
       end
     end
 

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SitemapGenerator::LinkSet do
-  let(:default_host) { 'http://example.com/' }
+  let(:default_host) { 'http://example.com' }
   let(:ls)           { SitemapGenerator::LinkSet.new(:default_host => default_host) }
 
   describe "initializer options" do
@@ -97,8 +97,8 @@ describe SitemapGenerator::LinkSet do
 
   describe "sitemaps url" do
     it "should change when the default_host is changed" do
-      ls.default_host = 'http://one.com/'
-      ls.default_host.should == 'http://one.com/'
+      ls.default_host = 'http://one.com'
+      ls.default_host.should == 'http://one.com'
       ls.default_host.should == ls.sitemap.location.host
       ls.default_host.should == ls.sitemap_index.location.host
     end
@@ -121,7 +121,7 @@ describe SitemapGenerator::LinkSet do
   describe "sitemap_index_url" do
     it "should return the url to the index file" do
       ls.default_host = default_host
-      ls.sitemap_index.location.url.should == URI.join(default_host, "/sitemap.xml.gz").to_s
+      ls.sitemap_index.location.url.should == "#{default_host}/sitemap.xml.gz"
       ls.sitemap_index_url.should == ls.sitemap_index.location.url
     end
   end
@@ -215,7 +215,7 @@ describe SitemapGenerator::LinkSet do
   end
 
   describe "sitemaps host" do
-    let(:new_host) { 'http://wowza.com/' }
+    let(:new_host) { 'http://wowza.com' }
 
     it "should have a host" do
       ls.default_host = default_host
@@ -253,7 +253,7 @@ describe SitemapGenerator::LinkSet do
 
     it "should not modify the index" do
       @ls.sitemaps_host = 'http://newhost.com'
-      @ls.sitemap.location.host.should == 'http://newhost.com/'
+      @ls.sitemap.location.host.should == 'http://newhost.com'
       @ls.sitemap_index.location.host.should == default_host
     end
 
@@ -345,7 +345,7 @@ describe SitemapGenerator::LinkSet do
       end
 
       it "should set the default_host" do
-        host = 'http://defaulthost.com/'
+        host = 'http://defaulthost.com'
         group = ls.group(:default_host => host)
         group.default_host.should == host
         group.sitemap.location.host.should == host
@@ -354,7 +354,7 @@ describe SitemapGenerator::LinkSet do
 
     describe "sitemaps_host" do
       it "should set the sitemaps host" do
-        @host = 'http://sitemaphost.com/'
+        @host = 'http://sitemaphost.com'
         @group = ls.group(:sitemaps_host => @host)
         @group.sitemaps_host.should == @host
         @group.sitemap.location.host.should == @host
@@ -403,7 +403,7 @@ describe SitemapGenerator::LinkSet do
       it "if only default_host is passed" do
         group = ls.group(:default_host => 'http://newhost.com')
         group.sitemap.should == ls.sitemap
-        group.sitemap.location.host.should == 'http://newhost.com/'
+        group.sitemap.location.host.should == 'http://newhost.com'
       end
     end
 
@@ -512,14 +512,14 @@ describe SitemapGenerator::LinkSet do
     end
 
     it "should set the default_host" do
-      host = 'http://defaulthost.com/'
+      host = 'http://defaulthost.com'
       ls.create(:default_host => host)
       ls.default_host.should == host
       ls.sitemap.location.host.should == host
     end
 
     it "should set the sitemaps host" do
-      host = 'http://sitemaphost.com/'
+      host = 'http://sitemaphost.com'
       ls.create(:sitemaps_host => host)
       ls.sitemaps_host.should == host
       ls.sitemap.location.host.should == host
@@ -590,7 +590,7 @@ describe SitemapGenerator::LinkSet do
   end
 
   describe "include_index?" do
-    let(:sitemaps_host)  { 'http://amazon.com/' }
+    let(:sitemaps_host)  { 'http://amazon.com' }
 
     it "should be true if no sitemaps_host set, or it is the same" do
       ls.include_index = true

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SitemapGenerator::LinkSet do
-  let(:default_host) { 'http://example.com' }
+  let(:default_host) { 'http://example.com/' }
   let(:ls)           { SitemapGenerator::LinkSet.new(:default_host => default_host) }
 
   describe "initializer options" do
@@ -97,8 +97,8 @@ describe SitemapGenerator::LinkSet do
 
   describe "sitemaps url" do
     it "should change when the default_host is changed" do
-      ls.default_host = 'http://one.com'
-      ls.default_host.should == 'http://one.com'
+      ls.default_host = 'http://one.com/'
+      ls.default_host.should == 'http://one.com/'
       ls.default_host.should == ls.sitemap.location.host
       ls.default_host.should == ls.sitemap_index.location.host
     end
@@ -121,7 +121,7 @@ describe SitemapGenerator::LinkSet do
   describe "sitemap_index_url" do
     it "should return the url to the index file" do
       ls.default_host = default_host
-      ls.sitemap_index.location.url.should == "#{default_host}/sitemap.xml.gz"
+      ls.sitemap_index.location.url.should == URI.join(default_host, "/sitemap.xml.gz").to_s
       ls.sitemap_index_url.should == ls.sitemap_index.location.url
     end
   end
@@ -215,7 +215,7 @@ describe SitemapGenerator::LinkSet do
   end
 
   describe "sitemaps host" do
-    let(:new_host) { 'http://wowza.com' }
+    let(:new_host) { 'http://wowza.com/' }
 
     it "should have a host" do
       ls.default_host = default_host
@@ -253,7 +253,7 @@ describe SitemapGenerator::LinkSet do
 
     it "should not modify the index" do
       @ls.sitemaps_host = 'http://newhost.com'
-      @ls.sitemap.location.host.should == 'http://newhost.com'
+      @ls.sitemap.location.host.should == 'http://newhost.com/'
       @ls.sitemap_index.location.host.should == default_host
     end
 
@@ -345,7 +345,7 @@ describe SitemapGenerator::LinkSet do
       end
 
       it "should set the default_host" do
-        host = 'http://defaulthost.com'
+        host = 'http://defaulthost.com/'
         group = ls.group(:default_host => host)
         group.default_host.should == host
         group.sitemap.location.host.should == host
@@ -354,7 +354,7 @@ describe SitemapGenerator::LinkSet do
 
     describe "sitemaps_host" do
       it "should set the sitemaps host" do
-        @host = 'http://sitemaphost.com'
+        @host = 'http://sitemaphost.com/'
         @group = ls.group(:sitemaps_host => @host)
         @group.sitemaps_host.should == @host
         @group.sitemap.location.host.should == @host
@@ -403,7 +403,7 @@ describe SitemapGenerator::LinkSet do
       it "if only default_host is passed" do
         group = ls.group(:default_host => 'http://newhost.com')
         group.sitemap.should == ls.sitemap
-        group.sitemap.location.host.should == 'http://newhost.com'
+        group.sitemap.location.host.should == 'http://newhost.com/'
       end
     end
 
@@ -512,14 +512,14 @@ describe SitemapGenerator::LinkSet do
     end
 
     it "should set the default_host" do
-      host = 'http://defaulthost.com'
+      host = 'http://defaulthost.com/'
       ls.create(:default_host => host)
       ls.default_host.should == host
       ls.sitemap.location.host.should == host
     end
 
     it "should set the sitemaps host" do
-      host = 'http://sitemaphost.com'
+      host = 'http://sitemaphost.com/'
       ls.create(:sitemaps_host => host)
       ls.sitemaps_host.should == host
       ls.sitemap.location.host.should == host
@@ -590,7 +590,7 @@ describe SitemapGenerator::LinkSet do
   end
 
   describe "include_index?" do
-    let(:sitemaps_host)  { 'http://amazon.com' }
+    let(:sitemaps_host)  { 'http://amazon.com/' }
 
     it "should be true if no sitemaps_host set, or it is the same" do
       ls.include_index = true

--- a/spec/sitemap_generator/sitemap_location_spec.rb
+++ b/spec/sitemap_generator/sitemap_location_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SitemapGenerator::SitemapLocation do
-  let(:default_host) { 'http://example.com/' }
+  let(:default_host) { 'http://example.com' }
   let(:location)     { SitemapGenerator::SitemapLocation.new }
 
   it "public_path should default to the public directory in the application root" do
@@ -100,7 +100,7 @@ describe SitemapGenerator::SitemapLocation do
   describe "when duplicated" do
     it "should not inherit some objects" do
       location = SitemapGenerator::SitemapLocation.new(:filename => 'xxx', :host => default_host, :public_path => 'public/')
-      location.url.should == URI.join(default_host, '/xxx').to_s
+      location.url.should == default_host+'/xxx'
       location.public_path.to_s.should == 'public/'
       dup = location.dup
       dup.url.should == location.url
@@ -145,7 +145,7 @@ describe SitemapGenerator::SitemapLocation do
       location = SitemapGenerator::SitemapLocation.new(
           :public_path => 'public/google', :filename => 'xxx',
           :host => default_host, :sitemaps_path => 'sub/dir')
-      location.url.should == URI.join(default_host, '/sub/dir/xxx').to_s
+      location.url.should == default_host + '/sub/dir/xxx'
     end
   end
 

--- a/spec/sitemap_generator/sitemap_location_spec.rb
+++ b/spec/sitemap_generator/sitemap_location_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe SitemapGenerator::SitemapLocation do
-  let(:default_host) { 'http://example.com' }
+  let(:default_host) { 'http://example.com/' }
   let(:location)     { SitemapGenerator::SitemapLocation.new }
 
   it "public_path should default to the public directory in the application root" do
@@ -33,6 +33,11 @@ describe SitemapGenerator::SitemapLocation do
     lambda {
       location.host.should be_nil
     }.should raise_error
+  end
+
+  it "should append slash to host" do
+    location = SitemapGenerator::SitemapLocation.new(:filename => nil, :namer => nil, :host => "http://www.slash.com")
+    location.host.should == "http://www.slash.com/"
   end
 
   it "should accept a Namer option" do
@@ -95,7 +100,7 @@ describe SitemapGenerator::SitemapLocation do
   describe "when duplicated" do
     it "should not inherit some objects" do
       location = SitemapGenerator::SitemapLocation.new(:filename => 'xxx', :host => default_host, :public_path => 'public/')
-      location.url.should == default_host+'/xxx'
+      location.url.should == URI.join(default_host, '/xxx').to_s
       location.public_path.to_s.should == 'public/'
       dup = location.dup
       dup.url.should == location.url
@@ -140,7 +145,7 @@ describe SitemapGenerator::SitemapLocation do
       location = SitemapGenerator::SitemapLocation.new(
           :public_path => 'public/google', :filename => 'xxx',
           :host => default_host, :sitemaps_path => 'sub/dir')
-      location.url.should == default_host + '/sub/dir/xxx'
+      location.url.should == URI.join(default_host, '/sub/dir/xxx').to_s
     end
   end
 


### PR DESCRIPTION
Also updated specs that check equality of host or host + path to expect
trailing slash for host.