### PR TITLE
added never write adapter, which exposes sitemap as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,10 @@ _This section needs better documentation.  Please consider contributing._
 
   Uses `carrierwave` to upload to any service supported by CarrierWave.
 
+* `SitemapGenerator::NeverWriteAdapter`
+
+  Exposes sitemap as a string--only use for small sitemaps.
+
 Some documentation exists [on the wiki page][remote_hosts].
 
 Sometimes it is desirable to host your sitemap files on a remote server and point robots

--- a/lib/sitemap_generator/adapters/never_write_adapter.rb
+++ b/lib/sitemap_generator/adapters/never_write_adapter.rb
@@ -1,0 +1,43 @@
+# this adapter never writes to a file.  However, it exposes the entire sitemap file as a string that can be cached using rails caching or any other means
+# this should only be used with small sitemaps.  Can also be useful for multi tenant applications where you want to generate a sitemap for each tenant independently
+#
+
+# in your controller
+#     data = Rails.cache.fetch("sitemap", expires_in: 12.hours) do
+#
+#       adapter = SitemapGenerator::NeverWriteAdapter.new
+#
+#       SitemapGenerator::Sitemap.create(
+#              :default_host => 'http://example.com',
+#              :adapter => adapter) do
+#          # your custom model queries
+#          Listing.where(deleted: false, open: true, community_id: 1).find_each do |listing|
+#            add listing_path(listing), :lastmod => listing.updated_at
+#          end
+#       end
+#       data = adapter.get_data
+#     end
+#     # do what you want with data
+
+
+module SitemapGenerator
+  class NeverWriteAdapter
+    @data 
+    def write(location, raw_data)
+      # never write
+      @data = raw_data
+    end
+
+    def plain(stream, data)
+      # never write
+
+    end
+    def gzip(stream, data)
+      # never write
+    end
+
+    def get_data
+      @data
+    end
+  end
+end


### PR DESCRIPTION
I found this useful in a different project and thought I'd see if you wanted to merge this.  Super simple, just adds a way to get the entire sitemap as a string for use with alternative caching methods, rather than writing it to a file.