### PR TITLE
Add append option to a linkset group

### DIFF
--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -314,6 +314,24 @@ describe SitemapGenerator::LinkSet do
       end
     end
 
+    describe "append" do
+      context "when passing a host without block" do
+        it "should set the value" do
+          @host = 'http://sitemaphost.com'
+
+          ls.expects(:finalize_sitemap!).never
+          ls.group(:sitemaps_host => @host, :append => true)
+        end
+      end
+
+      context "when passing a host with a block" do
+        it "should set the value" do
+          ls.expects(:finalize_sitemap!).never
+          ls.group(:sitemaps_host => 'http://test.com', :append => true) {}
+        end
+      end
+    end
+
     describe "verbose" do
       it "should inherit the value" do
         ls.group.verbose.should == ls.verbose


### PR DESCRIPTION
With the append option, a linkset's/group's sitemap won't be automatically finalized, allowing one to append links many different times into it without the sitemap being always overwritten. 

With this option though the linkset/group needs to be manually finalized, so the 'finalize_sitemap!' method it is now a public method.

Dummy example:

```
# sitemap.rb

Post.all.each do |post|
  if @posts_group.blank?
    @posts_group = group(filename: :posts, :append => true)
  end
  
  @posts_group.add(post_path(post))
end

@posts_group.finalize_sitemap!
```