### PR TITLE
AwsSdkAdapter default using aws-sdk-ruby default credential resolver

### DIFF
--- a/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
@@ -64,7 +64,7 @@ module SitemapGenerator
     end
 
     def has_specific_credential?
-      !@aws_access_key_id.nil? && !@@aws_secret_access_key.nil?
+      !@aws_access_key_id.nil? && !@aws_secret_access_key.nil?
     end
   end
 end

--- a/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
@@ -18,9 +18,9 @@ module SitemapGenerator
     def initialize(bucket, opts = {})
       @bucket = bucket
 
-      @aws_access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
-      @aws_region = opts[:aws_region] || ENV['AWS_REGION']
-      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
+      @aws_access_key_id = opts[:aws_access_key_id]
+      @aws_region = opts[:aws_region]
+      @aws_secret_access_key = opts[:aws_secret_access_key]
 
       @path = opts[:path] || 'sitemaps/'
     end
@@ -29,17 +29,42 @@ module SitemapGenerator
     def write(location, raw_data)
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
 
-      credentials = Aws::Credentials.new(@aws_access_key_id, @aws_secret_access_key)
-      s3 = Aws::S3::Resource.new(credentials: credentials, region: @aws_region)
-
       s3_object_key = "#{@path}#{location.path_in_public}"
-      s3_object = s3.bucket(@bucket).object(s3_object_key)
+      s3_object = s3_resource.bucket(@bucket).object(s3_object_key)
 
       content_type = location[:compress] ? 'application/x-gzip' : 'application/xml'
       s3_object.upload_file(location.path,
                             acl: 'public-read',
                             cache_control: 'private, max-age=0, no-cache',
                             content_type: content_type)
+    end
+
+    private
+
+    def s3_resource
+      @s3_resource ||= Aws::S3::Resource.new(s3_resource_option)
+    end
+
+    def s3_resource_option
+      option = {}
+      if has_specific_region?
+        option[:region] = @aws_region
+      end
+      if has_specific_credential?
+        option[:credentials] = Aws::Credentials.new(
+          @aws_access_key_id,
+          @aws_secret_access_key
+        )
+      end
+      option
+    end
+
+    def has_specific_region?
+      !@aws_region.nil?
+    end
+
+    def has_specific_credential?
+      !@aws_access_key_id.nil? && !@@aws_secret_access_key.nil?
     end
   end
 end


### PR DESCRIPTION
In the current behavior, you can not use instance profiles and task role in the instance that creates the sitemap.

aws-sdk-ruby v2 is auto detected using credentials.
According to the behavior of aws-sdk-ruby v2 unless you specify anything, explicitly specify that you use the specified credentials.
https://github.com/aws/aws-sdk-ruby/blob/master/aws-sdk-core/lib/aws-sdk-core/credential_provider_chain.rb#L10-L16

Backwards compatibility is preserved because environment variables are used in the default behavior of aws-sdk-ruby v2.

thanks