### PR TITLE
Fix up workaround for fog-core 1.2.0

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -1,7 +1,10 @@
 # Without this require, fog-core 1.2.0 raises
 # NameError: uninitialized constant Fog::ServicesMixin.
 # I don't know which versions this affects.
-require 'fog/core/services_mixin' rescue nil
+begin
+  require 'fog/core/services_mixin'
+rescue LoadError
+end
 
 begin
   require 'fog/storage'


### PR DESCRIPTION
Inline rescue fails to actually capture the LoadError exception.

```
pry(main)> require 'fog/core/services_mixin' rescue nil
LoadError: cannot load such file -- fog/core/services_mixin
```

Tested under Ruby 2.3.3.