### PR TITLE
Fix Circle CI build

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ ruby '1.9.3'
 
 gemspec
 
+gem 'public_suffix', '1.4.6'
+
 group :test do
   # gem 'debugger', :require => false
   # gem 'simplecov', :require => false

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '1.9.3'
 
 gemspec
 
+# 1.4.6 is the last version of this sub-dependency to support Rails < 2.0
 gem 'public_suffix', '1.4.6'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ ruby '1.9.3'
 gemspec
 
 group :test do
-  gem 'debugger', :require => false
+  # gem 'debugger', :require => false
   # gem 'simplecov', :require => false
 end

--- a/sitemap_generator.gemspec
+++ b/sitemap_generator.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.add_dependency 'builder', '~> 3.0'
   s.add_development_dependency 'fog-aws', '~> 1.2'
-  s.add_development_dependency 'nokogiri', '~> 1.6'
+  s.add_development_dependency 'nokogiri', '~> 1.6.8.1'
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'webmock', '~> 2.3'
   s.add_development_dependency 'rake', '~> 12'


### PR DESCRIPTION
The build was failing on sub-dependencies which now require Ruby > 2.  Lock those dependencies to versions which still support Ruby < 2