### PR TITLE
Add adapter for aws-sdk-v1 gem

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -11,6 +11,7 @@ module SitemapGenerator
   autoload(:FileAdapter,   'sitemap_generator/adapters/file_adapter')
   autoload(:S3Adapter,     'sitemap_generator/adapters/s3_adapter')
   autoload(:AwsSdkAdapter, 'sitemap_generator/adapters/aws_sdk_adapter')
+  autoload(:AwsSdkV1Adapter, 'sitemap_generator/adapters/aws_sdk_v1_adapter')
   autoload(:WaveAdapter,   'sitemap_generator/adapters/wave_adapter')
   autoload(:FogAdapter,    'sitemap_generator/adapters/fog_adapter')
   autoload(:BigDecimal,    'sitemap_generator/core_ext/big_decimal')

--- a/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
@@ -1,5 +1,5 @@
 begin
-  require 'aws'
+  require 'aws-sdk-v1'
 rescue LoadError
   raise LoadError.new("Missing required 'aws-sdk'.  Please 'gem install "\
                       "aws-sdk' and require it in your application, or "\

--- a/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
@@ -1,0 +1,48 @@
+begin
+  require 'aws'
+rescue LoadError
+  raise LoadError.new("Missing required 'aws-sdk'.  Please 'gem install "\
+                      "aws-sdk' and require it in your application, or "\
+                      "add: gem 'aws-sdk' to your Gemfile.")
+end
+
+module SitemapGenerator
+  # Class for uploading the sitemaps to an S3 bucket using the plain AWS SDK gem
+  class AwsSdkAdapter
+    # @param [String] bucket name of the S3 bucket
+    # @param [Hash]   opts   alternate means of configuration other than ENV
+    # @option opts  [String] :aws_access_key_id instead of ENV['AWS_ACCESS_KEY_ID']
+    # @option opts  [String] :aws_region instead of ENV['AWS_REGION']
+    # @option opts  [String] :aws_secret_access_key instead of ENV['AWS_SECRET_ACCESS_KEY']
+    # @option opts  [String] :path use this prefix on the object key instead of 'sitemaps/'
+    def initialize(bucket, opts = {})
+      @bucket = bucket
+
+      @aws_access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
+      @aws_region = opts[:aws_region] || ENV['AWS_REGION']
+      @aws_secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
+
+      @path = opts[:path] || 'sitemaps/'
+    end
+
+    # Call with a SitemapLocation and string data
+    def write(location, raw_data)
+      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+
+      s3 = AWS::S3.new(
+        access_key_id: @aws_access_key_id,
+        secret_access_key: @aws_secret_access_key
+      )
+
+      s3_object_key = "#{@path}#{location.filename}"
+      bucket = s3.buckets[@bucket]
+
+      begin
+        object = bucket.objects[s3_object_key]
+        object.write(file: location.path)
+      rescue Exception => e
+        raise e
+      end
+    end
+  end
+end

--- a/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
@@ -8,7 +8,7 @@ end
 
 module SitemapGenerator
   # Class for uploading the sitemaps to an S3 bucket using the plain AWS SDK gem
-  class AwsSdkAdapter
+  class AwsSdkV1Adapter
     # @param [String] bucket name of the S3 bucket
     # @param [Hash]   opts   alternate means of configuration other than ENV
     # @option opts  [String] :aws_access_key_id instead of ENV['AWS_ACCESS_KEY_ID']

--- a/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_v1_adapter.rb
@@ -1,9 +1,9 @@
 begin
   require 'aws-sdk-v1'
 rescue LoadError
-  raise LoadError.new("Missing required 'aws-sdk'.  Please 'gem install "\
-                      "aws-sdk' and require it in your application, or "\
-                      "add: gem 'aws-sdk' to your Gemfile.")
+  raise LoadError.new("Missing required 'aws-sdk-v1'.  Please 'gem install "\
+                      "aws-sdk-v1' and require it in your application, or "\
+                      "add: gem 'aws-sdk-v1' to your Gemfile.")
 end
 
 module SitemapGenerator
@@ -12,14 +12,12 @@ module SitemapGenerator
     # @param [String] bucket name of the S3 bucket
     # @param [Hash]   opts   alternate means of configuration other than ENV
     # @option opts  [String] :aws_access_key_id instead of ENV['AWS_ACCESS_KEY_ID']
-    # @option opts  [String] :aws_region instead of ENV['AWS_REGION']
     # @option opts  [String] :aws_secret_access_key instead of ENV['AWS_SECRET_ACCESS_KEY']
     # @option opts  [String] :path use this prefix on the object key instead of 'sitemaps/'
     def initialize(bucket, opts = {})
       @bucket = bucket
 
       @aws_access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
-      @aws_region = opts[:aws_region] || ENV['AWS_REGION']
       @aws_secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
 
       @path = opts[:path] || 'sitemaps/'


### PR DESCRIPTION
The current aws-sdk adapter doesn't work with the aws-sdk '< 2' or aws-sdk-v1 gem. For older projects still using paperclip or the v1 version of the gem this new adapter will work.