### PR TITLE
Allow use of just one fog platform

### DIFF
--- a/lib/sitemap_generator/adapters/fog_adapter.rb
+++ b/lib/sitemap_generator/adapters/fog_adapter.rb
@@ -1,7 +1,11 @@
-begin
-  require 'fog'
-rescue LoadError
-  raise LoadError.new("Missing required 'fog'.  Please 'gem install fog' and require it in your application.")
+# any number of storage method sub-gems, ex. fog-rackspace, could define this without
+# requiring the whole (large) fog project. If not, though, try loading everything.
+if !defined?(Fog::Storage)
+  begin
+    require 'fog'
+  rescue LoadError
+    raise LoadError.new("Missing required 'fog'.  Please 'gem install fog' and require it in your application.")
+  end
 end
 
 module SitemapGenerator


### PR DESCRIPTION
Previously, by requiring the root fog gem to be loaded, all gems
possibly supported by fog would need to be pulled in to the project,
since this is what the 'fog' gem does. Alternately, fog supports just
requiring a specific service, like S3 or Rackspace, by requiring the
services' fog gem specifically.

This commit adds support for the latter use case, allowing developers
to mimimize the number of gems pulled in to a project.