### PR TITLE
Fix Ruby 2.0.0+ compatibility.

### DIFF
--- a/lib/sitemap_generator/core_ext/big_decimal.rb
+++ b/lib/sitemap_generator/core_ext/big_decimal.rb
@@ -19,7 +19,7 @@ class SitemapGenerator::BigDecimal < BigDecimal
   #
   # Note that reconstituting YAML floats to native floats may lose precision.
   def to_yaml(opts = {})
-    return super if defined?(YAML::ENGINE) && !YAML::ENGINE.syck?
+    return super unless defined?(YAML::ENGINE) && YAML::ENGINE.syck?
 
     YAML.quick_emit(nil, opts) do |out|
       string = to_s


### PR DESCRIPTION
Testing this against Ruby 2.4, I observe following test error:

~~~
  1) SitemapGenerator::BigDecimal to_yaml should serialize correctly
     Failure/Error:
       YAML.quick_emit(nil, opts) do |out|
         string = to_s
         out.scalar(YAML_TAG, YAML_MAPPING[string] || string, :plain)
       end

     TypeError:
       can't define singleton method "encode_with" for SitemapGenerator::BigDecimal
     # /usr/share/ruby/psych/deprecated.rb:17:in `singleton_method_added'
     # /usr/share/ruby/psych/deprecated.rb:17:in `define_method'
     # /usr/share/ruby/psych/deprecated.rb:17:in `quick_emit'
     # ./lib/sitemap_generator/core_ext/big_decimal.rb:24:in `to_yaml'
     # ./spec/sitemap_generator/core_ext/bigdecimal_spec.rb:7:in `block (3 levels) in <top (required)>'
~~~

This happens because YAML::ENGINE is not available since Ruby 2.0.0+, when Syck was removed
from stdlib and replaced by Psych.

However, I am not sure if this is Ruby 1.8.7 compatible and if you care about it ...