### PR TITLE
Switch to AWS SDK version 3 and only use the two necessary gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ _This section needs better documentation.  Please consider contributing._
 
 * `SitemapGenerator::AwsSdkAdapter`
 
-  Uses `aws-sdk` to upload to Amazon S3 storage.
+  Uses AWS SDK (gems aws-sdk-core aws-sdk-s3) to upload to Amazon S3 storage.
 
 * `SitemapGenerator::WaveAdapter`
 

--- a/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
@@ -1,9 +1,9 @@
 begin
-  require 'aws-sdk'
+  require 'aws-sdk-s3'
 rescue LoadError
-  raise LoadError.new("Missing required 'aws-sdk'.  Please 'gem install "\
-                      "aws-sdk' and require it in your application, or "\
-                      "add: gem 'aws-sdk' to your Gemfile.")
+  raise LoadError.new("Missing required aws-sdk-s3.  Please 'gem install "\
+                      "aws-sdk-s3 and require it in your application, or "\
+                      "add: gem gem 'aws-sdk-s3' to your Gemfile.")
 end
 
 module SitemapGenerator


### PR DESCRIPTION
There is a similar PR which loads the whole AWS SDK version 3: https://github.com/kjvarga/sitemap_generator/pull/290, but there is really no point in loading all libraries for all AWS services while AWS SDK version 3 is modularized.