### PR TITLE
Add explanation about rake tasks autoloading on Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Alternatively, if you are not using a `Gemfile` add the gem to your `config/envi
 config.gem 'sitemap_generator'
 ```
 
+Note: SitemapGenerator automatically loads its Rake tasks when used with Rails. You **do not need** to require the `sitemap_generator/tasks` file.
+
 ## Getting Started
 
 ### Preventing Output


### PR DESCRIPTION
Hi @kjvarga,

First, thank you very much for maintaining this gem. I've been using it for years now and it never gave me any problems, as it's truly feature complete 👏.

This PR aims to add a small piece of info at the README, explaining to Rails users that they don't need to require the `sitemap_generator/tasks` file as explained on the previous Ruby Installation section.

A colleague happened to notice the sitemap generation was happening twice, and I noticed I've added the `require 'sitemap_generator/tasks'` on my Rails project Rakefile. SitemapGenerator was calling the config file twice because of this :)

Investigating a bit, I found the autoloading:

here:

https://github.com/kjvarga/sitemap_generator/blob/a6edcf5d8974d3450882bb6b9e12e33e01542f8d/lib/sitemap_generator.rb#L85 

and here:

https://github.com/kjvarga/sitemap_generator/blob/a6edcf5d8974d3450882bb6b9e12e33e01542f8d/lib/sitemap_generator/railtie.rb#L4