### PR TITLE
Use `yaml_tag` instead of `yaml_as`, which was deprecated in Ruby 2.4 and removed in 2.5

### DIFF
--- a/lib/sitemap_generator/core_ext/big_decimal.rb
+++ b/lib/sitemap_generator/core_ext/big_decimal.rb
@@ -12,7 +12,7 @@ class SitemapGenerator::BigDecimal < BigDecimal
   YAML_TAG = 'tag:yaml.org,2002:float'
   YAML_MAPPING = { 'Infinity' => '.Inf', '-Infinity' => '-.Inf', 'NaN' => '.NaN' }
 
-  yaml_as YAML_TAG
+  yaml_tag YAML_TAG
 
   # This emits the number without any scientific notation.
   # This is better than self.to_f.to_s since it doesn't lose precision.


### PR DESCRIPTION
Replace `yaml_as` with `yaml_tag` as directed by the deprecation warning. This allows sitemap_generator to work with Ruby 2.5.0. 🎉

I also ran the specs using Ruby 2.5.0 just to be sure – everything passes.

Fixes #297.