### PR TITLE
Use `yaml_tag` instead of deprecated `yaml_as`

### DIFF
--- a/lib/sitemap_generator/core_ext/big_decimal.rb
+++ b/lib/sitemap_generator/core_ext/big_decimal.rb
@@ -12,7 +12,7 @@ class SitemapGenerator::BigDecimal < BigDecimal
   YAML_TAG = 'tag:yaml.org,2002:float'
   YAML_MAPPING = { 'Infinity' => '.Inf', '-Infinity' => '-.Inf', 'NaN' => '.NaN' }
 
-  yaml_as YAML_TAG
+  yaml_tag YAML_TAG
 
   # This emits the number without any scientific notation.
   # This is better than self.to_f.to_s since it doesn't lose precision.


### PR DESCRIPTION
yaml_as is deprecated since Ruby 1.9.3.
ruby/ruby@5b5bbdb

And it will be remove in Ruby 2.5.0.
ruby/ruby@6d77e28