### PR TITLE
Fix rails instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Add the gem to your `Gemfile`:
 gem 'sitemap_generator'
 ```
 
-Alternatively, if you are not using a `Gemfile` add the gem to your `config/environment.rb` file config block:
+Alternatively, if you are not using a `Gemfile` add the gem to your `config/application.rb` file config block:
 
 ```ruby
 config.gem 'sitemap_generator'


### PR DESCRIPTION
The config block has been moved from environment.rb to application.rb some years back