### PR TITLE
Add schema for News-specific elements

### DIFF
--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -30,7 +30,8 @@ module SitemapGenerator
             <urlset
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
               xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-                http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+                http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
+                http://www.google.com/schemas/sitemap-news/0.9/sitemap-news.xsd"
               xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
               xmlns:image="#{SitemapGenerator::SCHEMAS['image']}"
               xmlns:video="#{SitemapGenerator::SCHEMAS['video']}"


### PR DESCRIPTION
According to Google you need this header https://support.google.com/news/publisher-center/answer/184732?hl=en

Without that header it fails to validate a sitemap

<img width="1015" alt="screen shot 2018-08-02 at 11 39 43 am" src="https://user-images.githubusercontent.com/253398/43569544-d43ea574-9648-11e8-9eac-8a17fc7c4469.png">
