### PR TITLE
Fix NoMethodError error on Ruby 2.4 and older. 

### DIFF
--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -295,7 +295,11 @@ module SitemapGenerator
         name = Utilities.titleize(engine.to_s)
         begin
           Timeout::timeout(10) {
-            URI.open(link)
+            if URI.respond_to?(:open) # Available since Ruby 2.5
+              URI.open(link)
+            else
+              open(link) # using Kernel#open became deprecated since Ruby 2.7. See https://bugs.ruby-lang.org/issues/15893
+            end
           }
           output("  Successful ping of #{name}")
         rescue Timeout::Error, StandardError => e


### PR DESCRIPTION
Fixes https://github.com/kjvarga/sitemap_generator/issues/352

`NoMethodError: private method 'open' called for URI:Module` was raised on older rubies as `URI.open` was added only in Ruby 2.5: https://rubyreferences.github.io/rubychanges/2.5.html#network-and-web