### PR TITLE
Update google cloud adapter to support ruby 3 kwarg changes

### DIFF
--- a/lib/sitemap_generator/adapters/google_storage_adapter.rb
+++ b/lib/sitemap_generator/adapters/google_storage_adapter.rb
@@ -29,7 +29,7 @@ module SitemapGenerator
     def write(location, raw_data)
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
 
-      storage = Google::Cloud::Storage.new(@storage_options)
+      storage = Google::Cloud::Storage.new(**@storage_options)
       bucket = storage.bucket(@bucket)
       bucket.create_file(location.path, location.path_in_public, acl: 'public')
     end


### PR DESCRIPTION
Due to [ruby 3 changes to kwargs](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) the arguments of the hash were no longer being accepted on the GCloud initializer. Use the double splat operator to fix this issue

Hope to fix issue https://github.com/kjvarga/sitemap_generator/issues/371