### PR TITLE
Fix to pass specs with rspec-mocks 3.10.3 or later

### DIFF
--- a/spec/sitemap_generator/builder/sitemap_file_spec.rb
+++ b/spec/sitemap_generator/builder/sitemap_file_spec.rb
@@ -97,13 +97,13 @@ describe 'SitemapGenerator::Builder::SitemapFile' do
   describe 'add' do
     it 'should use the host provided' do
       url = SitemapGenerator::Builder::SitemapUrl.new('/one', :host => 'http://newhost.com/')
-      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new).with('/one', :host => 'http://newhost.com').and_return(url)
+      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new).with('/one', { :host => 'http://newhost.com' }).and_return(url)
       sitemap.add '/one', :host => 'http://newhost.com'
     end
 
     it 'should use the host from the location' do
       url = SitemapGenerator::Builder::SitemapUrl.new('/one', :host => 'http://example.com/')
-      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new).with('/one', :host => 'http://example.com/').and_return(url)
+      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new).with('/one', { :host => 'http://example.com/' }).and_return(url)
       sitemap.add '/one'
     end
   end

--- a/spec/sitemap_generator/builder/sitemap_index_file_spec.rb
+++ b/spec/sitemap_generator/builder/sitemap_index_file_spec.rb
@@ -75,13 +75,13 @@ describe 'SitemapGenerator::Builder::SitemapIndexFile' do
   describe 'add' do
     it 'should use the host provided' do
       url = SitemapGenerator::Builder::SitemapIndexUrl.new('/one', :host => 'http://newhost.com/')
-      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new).with('/one', :host => 'http://newhost.com').and_return(url)
+      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new).with('/one', { :host => 'http://newhost.com' }).and_return(url)
       index.add '/one', :host => 'http://newhost.com'
     end
 
     it 'should use the host from the location' do
       url = SitemapGenerator::Builder::SitemapIndexUrl.new('/one', :host => 'http://example.com/')
-      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new).with('/one', :host => 'http://example.com/').and_return(url)
+      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new).with('/one', { :host => 'http://example.com/' }).and_return(url)
       index.add '/one'
     end
 

--- a/spec/sitemap_generator/interpreter_spec.rb
+++ b/spec/sitemap_generator/interpreter_spec.rb
@@ -35,14 +35,14 @@ describe SitemapGenerator::Interpreter do
   describe 'public interface' do
     describe 'add' do
       it 'should add a link to the sitemap' do
-        expect(link_set).to receive(:add).with('test', :option => 'value')
+        expect(link_set).to receive(:add).with('test', { :option => 'value' })
         interpreter.add('test', :option => 'value')
       end
     end
 
     describe 'group' do
       it 'should start a new group' do
-        expect(link_set).to receive(:group).with('test', :option => 'value')
+        expect(link_set).to receive(:group).with('test', { :option => 'value' })
         interpreter.group('test', :option => 'value')
       end
     end
@@ -55,7 +55,7 @@ describe SitemapGenerator::Interpreter do
 
     describe 'add_to_index' do
       it 'should add a link to the sitemap index' do
-        expect(link_set).to receive(:add_to_index).with('test', :option => 'value')
+        expect(link_set).to receive(:add_to_index).with('test', { :option => 'value' })
         interpreter.add_to_index('test', :option => 'value')
       end
     end

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -679,13 +679,13 @@ describe SitemapGenerator::LinkSet do
 
     it 'should add the link to the sitemap and include the default host' do
       expect(ls).to receive(:add_default_links)
-      expect(ls.sitemap).to receive(:add).with('/home', :host => ls.default_host)
+      expect(ls.sitemap).to receive(:add).with('/home', { :host => ls.default_host })
       ls.add('/home')
     end
 
     it 'should allow setting of a custom host' do
       expect(ls).to receive(:add_default_links)
-      expect(ls.sitemap).to receive(:add).with('/home', :host => 'http://newhost.com')
+      expect(ls.sitemap).to receive(:add).with('/home', { :host => 'http://newhost.com' })
       ls.add('/home', :host => 'http://newhost.com')
     end
 
@@ -710,17 +710,17 @@ describe SitemapGenerator::LinkSet do
     describe 'host' do
       it 'should be the sitemaps_host' do
         ls.sitemaps_host = 'http://sitemapshost.com'
-        expect(ls.sitemap_index).to receive(:add).with('/home', :host => 'http://sitemapshost.com')
+        expect(ls.sitemap_index).to receive(:add).with('/home', { :host => 'http://sitemapshost.com' })
         ls.add_to_index('/home')
       end
 
       it 'should be the default_host if no sitemaps_host set' do
-        expect(ls.sitemap_index).to receive(:add).with('/home', :host => ls.default_host)
+        expect(ls.sitemap_index).to receive(:add).with('/home', { :host => ls.default_host })
         ls.add_to_index('/home')
       end
 
       it 'should allow setting a custom host' do
-        expect(ls.sitemap_index).to receive(:add).with('/home', :host => 'http://newhost.com')
+        expect(ls.sitemap_index).to receive(:add).with('/home', { :host => 'http://newhost.com' })
         ls.add_to_index('/home', :host => 'http://newhost.com')
       end
     end


### PR DESCRIPTION
Fixed an issue that caused an error in rspec-mock version 3.10.3 or later.
With [this PR](https://github.com/rspec/rspec-mocks/pull/1394), the behavior when passing a keyword argument to `with` has changed.