### PR TITLE
Remove Bing ping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+* Removes deprecated Bing notification URL. See advisory for alternative ways
+  to notify Bing:
+  https://blogs.bing.com/webmaster/may-2022/Spring-cleaning-Removed-Bing-anonymous-sitemap-submission
+
 ### 6.2.1
 
 * Bugfix: Improve handling of deprecated options in `AwsSdkAdapter`.  Fixes bug where `:region` was being set to `nil`. [#390](https://github.com/kjvarga/sitemap_generator/pull/390).

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Sitemaps adhere to the [Sitemap 0.9 protocol][sitemap_protocol] specification.
 * Adheres to the [Sitemap 0.9 protocol][sitemap_protocol]
 * Handles millions of links
 * Customizable sitemap compression
-* Notifies search engines (Google, Bing) of new sitemaps
+* Notifies Google of new sitemaps
 * Ensures your old sitemaps stay in place if the new sitemap fails to generate
 * Gives you complete control over your sitemap contents and naming scheme
 * Intelligent sitemap indexing
@@ -58,7 +58,6 @@ In /Users/karl/projects/sitemap_generator-test/public/
 Sitemap stats: 3 links / 1 sitemaps / 0m00s
 
 Successful ping of Google
-Successful ping of Bing
 ```
 
 ## Contents
@@ -205,7 +204,7 @@ SitemapGenerator.verbose = false
 
 ### Pinging Search Engines
 
-Using `rake sitemap:refresh` will notify Google and Bing to let them know that a new sitemap
+Using `rake sitemap:refresh` will notify Google to let it know that a new sitemap
 is available.  To generate new sitemaps without notifying search engines, use `rake sitemap:refresh:no_ping`.
 
 If you want to customize the hash of search engines you can access it at:

--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -125,8 +125,7 @@ module SitemapGenerator
         :include_index => false,
         :filename => :sitemap,
         :search_engines => {
-          :google         => "http://www.google.com/webmasters/tools/ping?sitemap=%s",
-          :bing           => "http://www.bing.com/webmaster/ping.aspx?sitemap=%s"
+          :google => "http://www.google.com/webmasters/tools/ping?sitemap=%s"
         },
         :create_index => :auto,
         :compress => true,

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -130,12 +130,12 @@ describe SitemapGenerator::LinkSet do
   describe 'search_engines' do
     it 'should have search engines by default' do
       expect(ls.search_engines).to be_a(Hash)
-      expect(ls.search_engines.size).to eq(2)
+      expect(ls.search_engines.size).to eq(1)
     end
 
     it 'should support being modified' do
       ls.search_engines[:newengine] = 'abc'
-      expect(ls.search_engines.size).to eq(3)
+      expect(ls.search_engines.size).to eq(2)
     end
 
     it 'should support being set to nil' do


### PR DESCRIPTION
The Bing anonymous sitemap submission has been deprecated:
https://blogs.bing.com/webmaster/may-2022/Spring-cleaning-Removed-Bing-anonymous-sitemap-submission

This change prevents errors such as:

```
Pinging with URL https://www.gasi.ch/sitemap.xml.gz:
  Successful ping of Google
Ping failed for Bing: #<OpenURI::HTTPError: 410 Gone> (URL http://www.bing.com/ping?sitemap=https%3A%2F%2Fwww.gasi.ch%2Fsitemap.xml.gz)
```
