### PR TITLE
[Example] Support Coveo metadata

### DIFF
--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -38,6 +38,7 @@ module SitemapGenerator
               xmlns:mobile="#{SitemapGenerator::SCHEMAS['mobile']}"
               xmlns:pagemap="#{SitemapGenerator::SCHEMAS['pagemap']}"
               xmlns:xhtml="http://www.w3.org/1999/xhtml"
+              xmlns:coveo="https://www.coveo.com/en/company/about-us"
             >
         HTML
         @xml_wrapper_start.gsub!(/\s+/, ' ').gsub!(/ *> */, '>').strip!

--- a/lib/sitemap_generator/builder/sitemap_url.rb
+++ b/lib/sitemap_generator/builder/sitemap_url.rb
@@ -42,7 +42,7 @@ module SitemapGenerator
 
         SitemapGenerator::Utilities.assert_valid_keys(
           options,
-          :priority, :changefreq, :lastmod, :expires, :host, :images, :video, :news, :videos, :mobile, :alternate, :alternates, :pagemap
+          :priority, :changefreq, :lastmod, :expires, :host, :images, :video, :news, :videos, :mobile, :alternate, :alternates, :pagemap, :coveo
         )
         SitemapGenerator::Utilities.reverse_merge!(
           options,
@@ -78,7 +78,8 @@ module SitemapGenerator
           :videos     => options[:videos],
           :mobile     => options[:mobile],
           :alternates => options[:alternates],
-          :pagemap    => options[:pagemap]
+          :pagemap    => options[:pagemap],
+          :coveo      => options[:coveo]
         )
       end
 
@@ -91,6 +92,14 @@ module SitemapGenerator
           builder.expires    w3c_date(self[:expires])      if self[:expires]
           builder.changefreq self[:changefreq].to_s        if self[:changefreq]
           builder.priority   format_float(self[:priority]) if self[:priority]
+
+          unless SitemapGenerator::Utilities.blank?(self[:coveo])
+            coveo_data = self[:coveo]
+            builder.coveo:metadata do
+              builder.casenumber coveo_data[:case_number].to_s if coveo_data[:case_number]
+              builder.company_name coveo_data[:company_name].to_s if coveo_data[:company_name]
+            end
+          end
 
           unless SitemapGenerator::Utilities.blank?(self[:news])
             news_data = self[:news]


### PR DESCRIPTION
An example of how to support Coveo metadata https://docs.coveo.com/en/2656/index-content/index-xml-sitemap-metadata

### Here's an example sitemap

```
SitemapGenerator::Sitemap.default_host = "http://www.example.com"
SitemapGenerator::Sitemap.compress = false
SitemapGenerator::Sitemap.create do
  add '/contents', coveo: { case_number: '12345', company_name: 'Publication Name' }
end
```

### And output
```
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
  xmlns:video="http://www.google.com/schemas/sitemap-video/1.1"
  xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
  xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
  xmlns:pagemap="http://www.google.com/schemas/sitemap-pagemap/1.0"
  xmlns:xhtml="http://www.w3.org/1999/xhtml"
  xmlns:coveo="https://www.coveo.com/en/company/about-us">
  <url>
    <loc>http://www.example.com</loc>
    <lastmod>2022-08-15T11:31:53-07:00</lastmod>
    <changefreq>weekly</changefreq>
    <priority>1.0</priority>
  </url>
  <url>
    <loc>http://www.example.com/contents</loc>
    <lastmod>2022-08-15T11:31:53-07:00</lastmod>
    <changefreq>weekly</changefreq>
    <priority>0.5</priority>
    <coveo:metadata>
      <casenumber>12345</casenumber>
      <company_name>Publication Name</company_name>
    </coveo:metadata>
  </url>
</urlset>
```
