### PR TITLE
Support AWS Lambda

### DIFF
--- a/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
+++ b/lib/sitemap_generator/adapters/aws_sdk_adapter.rb
@@ -29,13 +29,14 @@ module SitemapGenerator
     #   All other options you provide are passed directly to the AWS client.
     #   See https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/S3/Client.html#initialize-instance_method
     #   for a full list of supported options.
-    def initialize(bucket, aws_access_key_id: nil, aws_secret_access_key: nil, aws_region: nil, aws_endpoint: nil, acl: 'public-read', cache_control: 'private, max-age=0, no-cache', **options)
+    def initialize(bucket, aws_access_key_id: nil, aws_secret_access_key: nil, aws_session_token: nil, aws_region: nil, aws_endpoint: nil, acl: 'public-read', cache_control: 'private, max-age=0, no-cache', **options)
       @bucket = bucket
       @acl = acl
       @cache_control = cache_control
       @options = options
       set_option_unless_set(:access_key_id, aws_access_key_id)
       set_option_unless_set(:secret_access_key, aws_secret_access_key)
+      set_option_unless_set(:session_token, aws_session_token)
       set_option_unless_set(:region, aws_region)
       set_option_unless_set(:endpoint, aws_endpoint)
     end

--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -25,6 +25,7 @@ module SitemapGenerator
     def initialize(opts = {})
       @aws_access_key_id = opts[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
       @aws_secret_access_key = opts[:aws_secret_access_key] || ENV['AWS_SECRET_ACCESS_KEY']
+      @aws_session_token = opts[:aws_session_token] || ENV['AWS_SESSION_TOKEN']
       @fog_provider = opts[:fog_provider] || ENV['FOG_PROVIDER']
       @fog_directory = opts[:fog_directory] || ENV['FOG_DIRECTORY']
       @fog_region = opts[:fog_region] || ENV['FOG_REGION']
@@ -43,6 +44,7 @@ module SitemapGenerator
       if @aws_access_key_id && @aws_secret_access_key
         credentials[:aws_access_key_id] = @aws_access_key_id
         credentials[:aws_secret_access_key] = @aws_secret_access_key
+        credentials[:aws_session_token] = @aws_session_token if @aws_session_token
       else
         credentials[:use_iam_profile] = true
       end

--- a/spec/sitemap_generator/adapters/s3_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/s3_adapter_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe SitemapGenerator::S3Adapter do
     {
       aws_access_key_id: 'aws_access_key_id',
       aws_secret_access_key: 'aws_secret_access_key',
+      aws_session_token: 'aws_session_token',
       fog_provider: 'fog_provider',
       fog_directory: 'fog_directory',
       fog_region: 'fog_region',
@@ -51,6 +52,7 @@ RSpec.describe SitemapGenerator::S3Adapter do
     it 'sets options on the instance' do
       expect(adapter.instance_variable_get(:@aws_access_key_id)).to eq('aws_access_key_id')
       expect(adapter.instance_variable_get(:@aws_secret_access_key)).to eq('aws_secret_access_key')
+      expect(adapter.instance_variable_get(:@aws_session_token)).to eq('aws_session_token')
       expect(adapter.instance_variable_get(:@fog_provider)).to eq('fog_provider')
       expect(adapter.instance_variable_get(:@fog_directory)).to eq('fog_directory')
       expect(adapter.instance_variable_get(:@fog_region)).to eq('fog_region')


### PR DESCRIPTION
I tried to use on AWS Lambda and needed to patch a little bit. Instead of fetching metadata like EC2 or ECS, AWS Lambda initially has `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_SESSION_TOKEN` from the beginning, as reserved environment variables. In this case, we need to pass these variables directly into fog or `Aws::S3::Resource`.