### PR TITLE
Avoid duplicates in links set

### DIFF
--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -693,6 +693,18 @@ describe SitemapGenerator::LinkSet do
       expect(ls).to receive(:add_default_links)
       ls.add('/home')
     end
+
+    context 'when link added twice' do
+      before do
+        ls.include_root = false
+        ls.add('/home')
+        ls.add('/home')
+      end
+      
+      it 'should not add link that already added' do
+        expect(ls.sitemap.link_count).to eq(1)
+      end
+    end
   end
 
   describe 'add_to_index' do


### PR DESCRIPTION
Hey there, thank you for the gem.

In our current project we have regular rails routes and `redirects` table where we store redirect mapping. Links form `redirects` table sometimes may have intersection with routes.

This PR adds functionality to avoid duplicates.

Please review and let me know if I have to change something 🙏  Thanks!