### PR TITLE
Fix Ruby "method redefined" warning

### DIFF
--- a/lib/sitemap_generator/templates.rb
+++ b/lib/sitemap_generator/templates.rb
@@ -13,7 +13,7 @@ module SitemapGenerator
     }
 
     # Dynamically define accessors for each key defined in <tt>FILES</tt>
-    attr_accessor(*FILES.keys)
+    attr_writer(*FILES.keys)
 
     FILES.each_key do |name|
       eval(<<-ACCESSOR, binding, __FILE__ , __LINE__ + 1)


### PR DESCRIPTION
When Ruby warnings are enabled, this is printed when loading the sitemap_generator gem:

> sitemap_generator-6.3.0/lib/sitemap_generator/templates.rb:16):1: warning: method redefined; discarding old sitemap_sample

This is because an attr reader (e.g. `sitemap_sample`) was being defined via `attr_accessor` and then immediately redefined with `define_method`.

Fix by using `attr_writer` instead of `attr_accessor`, so that the attr reader is not defined twice.