### PR TITLE
Add support for Ruby 3.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
+          - '3.4'
           - '3.3'
           - '3.2'
           - '3.1'

--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -26,8 +26,8 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapLocation.new(opts) : opts
         @link_count = 0
         @news_count = 0
-        @xml_content = +'' # XML urlset content
-        @xml_wrapper_start = +<<-HTML
+        @xml_content = String.new # XML urlset content
+        @xml_wrapper_start = <<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <urlset
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -138,8 +138,8 @@ module SitemapGenerator
         raise SitemapGenerator::SitemapError.new("Sitemap already written!") if written?
         finalize! unless finalized?
         reserve_name
-        @location.write(@xml_wrapper_start + @xml_content + @xml_wrapper_end, link_count)
-        @xml_content = @xml_wrapper_start = @xml_wrapper_end = ''
+        @location.write("#{@xml_wrapper_start}#{@xml_content}#{@xml_wrapper_end}", link_count)
+        @xml_content = @xml_wrapper_start = @xml_wrapper_end = String.new
         @written = true
       end
 

--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -26,7 +26,6 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapLocation.new(opts) : opts
         @link_count = 0
         @news_count = 0
-        @xml_content = String.new # XML urlset content
         @xml_wrapper_start = <<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <urlset
@@ -43,8 +42,9 @@ module SitemapGenerator
             >
         HTML
         @xml_wrapper_start.gsub!(/\s+/, ' ').gsub!(/ *> */, '>').strip!
-        @xml_wrapper_end   = %q[</urlset>]
+        @xml_wrapper_end = '</urlset>'
         @filesize = SitemapGenerator::Utilities.bytesize(@xml_wrapper_start) + SitemapGenerator::Utilities.bytesize(@xml_wrapper_end)
+        @xml_content = @xml_wrapper_start
         @written = false
         @reserved_name = nil # holds the name reserved from the namer
         @frozen = false      # rather than actually freeze, use this boolean
@@ -138,8 +138,9 @@ module SitemapGenerator
         raise SitemapGenerator::SitemapError.new("Sitemap already written!") if written?
         finalize! unless finalized?
         reserve_name
-        @location.write("#{@xml_wrapper_start}#{@xml_content}#{@xml_wrapper_end}", link_count)
-        @xml_content = @xml_wrapper_start = @xml_wrapper_end = String.new
+        @xml_content << @xml_wrapper_end
+        @location.write(@xml_content, link_count)
+        @xml_content = @xml_wrapper_end = ''
         @written = true
       end
 

--- a/lib/sitemap_generator/builder/sitemap_index_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_index_file.rb
@@ -12,7 +12,6 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapIndexLocation.new(opts) : opts
         @link_count = 0
         @sitemaps_link_count = 0
-        @xml_content = +'' # XML urlset content
         @xml_wrapper_start = +<<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <sitemapindex
@@ -23,8 +22,9 @@ module SitemapGenerator
             >
         HTML
         @xml_wrapper_start.gsub!(/\s+/, ' ').gsub!(/ *> */, '>').strip!
-        @xml_wrapper_end   = %q[</sitemapindex>]
+        @xml_wrapper_end = '</sitemapindex>'
         @filesize = SitemapGenerator::Utilities.bytesize(@xml_wrapper_start) + SitemapGenerator::Utilities.bytesize(@xml_wrapper_end)
+        @xml_content = @xml_wrapper_start
         @written = false
         @reserved_name = nil # holds the name reserved from the namer
         @frozen = false      # rather than actually freeze, use this boolean


### PR DESCRIPTION
This pull request updates XML generation to be compatible with Ruby 3.4's default frozen string literals and optimizes string handling for better performance.

-  It resolves warnings when running the gem in a Ruby 3.4 application, where frozen string literals are enabled by default, and prepares for Ruby 3.5's upcoming default behavior. This change anticipates `frozen_string_literals` becoming the default in Ruby 3.5.

-  It expands test coverage by adding Ruby 3.4 to the test matrix to ensure compatibility with the latest Ruby version.

-  It optimizes memory usage in XML generation by preventing unnecessary string duplication when writing. It eliminates the need to duplicate entire strings when adding wrappers at the beginning and end, significantly reducing memory allocations and garbage collections, which is particularly beneficial for generating large sitemaps.