### PR TITLE
Adapt code to frozen string literal, reduce string copies

### DIFF
--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -26,8 +26,7 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapLocation.new(opts) : opts
         @link_count = 0
         @news_count = 0
-        @xml_content = +'' # XML urlset content
-        @xml_wrapper_start = +<<-HTML
+        @xml_wrapper_start = <<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <urlset
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -45,6 +44,7 @@ module SitemapGenerator
         @xml_wrapper_start.gsub!(/\s+/, ' ').gsub!(/ *> */, '>').strip!
         @xml_wrapper_end = '</urlset>'
         @filesize = SitemapGenerator::Utilities.bytesize(@xml_wrapper_start) + SitemapGenerator::Utilities.bytesize(@xml_wrapper_end)
+        @xml_content = @xml_wrapper_start
         @written = false
         @reserved_name = nil # holds the name reserved from the namer
         @frozen = false      # rather than actually freeze, use this boolean
@@ -141,8 +141,9 @@ module SitemapGenerator
 
         finalize! unless finalized?
         reserve_name
-        @location.write(@xml_wrapper_start + @xml_content + @xml_wrapper_end, link_count)
-        @xml_content = @xml_wrapper_start = @xml_wrapper_end = ''
+        @xml_content << @xml_wrapper_end
+        @location.write(@xml_content, link_count)
+        @xml_content = @xml_wrapper_end = ''
         @written = true
       end
 

--- a/lib/sitemap_generator/builder/sitemap_index_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_index_file.rb
@@ -12,7 +12,6 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapIndexLocation.new(opts) : opts
         @link_count = 0
         @sitemaps_link_count = 0
-        @xml_content = +'' # XML urlset content
         @xml_wrapper_start = +<<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <sitemapindex
@@ -25,6 +24,7 @@ module SitemapGenerator
         @xml_wrapper_start.gsub!(/\s+/, ' ').gsub!(/ *> */, '>').strip!
         @xml_wrapper_end = '</sitemapindex>'
         @filesize = SitemapGenerator::Utilities.bytesize(@xml_wrapper_start) + SitemapGenerator::Utilities.bytesize(@xml_wrapper_end)
+        @xml_content = @xml_wrapper_start
         @written = false
         @reserved_name = nil # holds the name reserved from the namer
         @frozen = false      # rather than actually freeze, use this boolean

--- a/lib/sitemap_generator/utilities.rb
+++ b/lib/sitemap_generator/utilities.rb
@@ -142,9 +142,9 @@ module SitemapGenerator
     end
 
     def titleize(string)
-      string = string.dup if string.frozen?
-      string.gsub!(/_/, ' ')
-      string.split(/(\W)/).map(&:capitalize).join
+      result = string.tr('_', ' ')
+      result.gsub!(/\b\w/) { |match| match.upcase }
+      result
     end
 
     def truthy?(value)


### PR DESCRIPTION
Avoids last frozen string literal warnings by implying the passed string will always be frozen in upcoming Ruby versions.

Also reduces object allocations, including string copies, arrays, and maps, backported partly from #445 which it replaces.