### PR TITLE
Support for building sitemaps without block

### DIFF
--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -40,7 +40,7 @@ module SitemapGenerator
         puts "In '#{sitemap_index.location.public_path}':"
       end
       interpreter.eval(yield_sitemap: yield_sitemap?, &block)
-      finalize!
+      finalize! if block_given?
       end_time = Time.now if verbose
       output(sitemap_index.stats_summary(time_taken: end_time - start_time)) if verbose
       self

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -481,10 +481,6 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'options to create' do
-    before do
-      expect(ls).to receive(:finalize!)
-    end
-
     it 'should set include_index' do
       original = ls.include_index
       expect(ls.create(:include_index => !original).include_index).not_to eq(original)
@@ -563,6 +559,20 @@ RSpec.describe SitemapGenerator::LinkSet do
     it 'should set create_index' do
       ls.create(:create_index => :auto)
       expect(ls.create_index).to eq(:auto)
+    end
+
+    it 'should not call finalize!' do
+      expect(ls).to receive(:finalize!).never
+      ls.create({})
+    end
+
+    context 'when block is given' do
+      it 'should finalize! after the block' do
+        expect(ls).to receive(:finalize!)
+        ls.create do
+          add('/test')
+        end
+      end
     end
   end
 

--- a/spec/sitemap_generator/sitemaps/no_block_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/no_block_sitemap_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe 'SitemapGenerator' do
+
+  it 'should generate sitemaps without blocks' do
+    sitemap = SitemapGenerator::Sitemap.create(default_host: 'http://www.example.com', compress: false)
+
+    sitemap.add('/home')
+
+    blog_group = sitemap.group(filename: :blog, default_host: 'http://example.com/blog')
+    blog_group.add('post1')
+    blog_group.finalize!
+
+    news_group = sitemap.group(filename: :news, default_host: 'http://example.com/news')
+    news_group.add('news1')
+    news_group.add('news2')
+    news_group.finalize!
+
+    sitemap.finalize!
+  end
+end


### PR DESCRIPTION
You can create a sitemap without a block normally, but when you add groups it simply doesn't work. An example of it is:

```ruby
sitemap = SitemapGenerator::Sitemap.create(default_host: 'http://www.example.com', compress: false)

sitemap.add('/home')

blog_group = sitemap.group(filename: :blog, default_host: 'http://example.com/blog')
blog_group.add('post1')
blog_group.finalize!

news_group = sitemap.group(filename: :news, default_host: 'http://example.com/news')
news_group.add('news1')
news_group.add('news2')
news_group.finalize!

sitemap.finalize!
```

Of course, such example is not realistic as you would normally use blocks to accomplish this, however, in a more structure code having this is not possible. For example, I had a class that took care of generating the sitemap, but I needed a custom implementation in another class. I inherited from the original, but I was unable to generate groups without facing errors, specifically `SitemapFinalizedError`. Example:

```ruby
class BaseGenerator
  include ApplicationHelper

  attr_reader :site

  def initialize(site)
    @site = site
  end

  def generate
    default_configuration!

    sitemap = SitemapGenerator::Sitemap.create

    sitemap.add_site_pages(site)

    sitemap.finalize!
  end

  protected

  def default_configuration!
    SitemapGenerator::Sitemap.default_host = site.url
  end

  def add_site_pages(sitemap)
    site.pages.each do |page|
      sitemap.add(page.path, lastmod: page.updated_at)
    end
  end

  def record_slug(item)
    item.slug.present? ? item.slug : item.id
  end
end


class MySubSiteGenerator < BaseGenerator
  protected

  def add_site_pages(sitemap)
    group_products(sitemap)
    group_blogs(sitemap)
  end

  def add_products(sitemap)
    group = sitemap.group(filename: 'products_sitemap')

    site.products.each do |product|
      group.add(product.path, lastmod: product.updated_at)
    end

    group.finalize! # Throws error
  end

  def group_blogs(sitemap)
     sitemap.group(filename: 'blogs_sitemap') do # Throws error
      site.blogs.each do |blog|
        add(record_slug(blog), lastmod: blog.updated_at) # Can't access record_slug due to context beiong changed to Interpreter class
      end
    end
  end
end
```

This simple change seems to accomplish this separation, and both approaches seem to work.
