### PR TITLE
Remove cgi dependency (fix Ruby 4 error)

### DIFF
--- a/lib/sitemap_generator/link_set.rb
+++ b/lib/sitemap_generator/link_set.rb
@@ -279,13 +279,13 @@ module SitemapGenerator
     #
     #   SitemapGenerator::Sitemap.ping_search_engines('http://example.com/sitemap.xml.gz', :super_engine => 'http://superengine.com/ping?url=%s')
     def ping_search_engines(*args) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
-      require 'cgi/session'
       require 'open-uri'
       require 'timeout'
+      require 'uri'
 
       engines = args.last.is_a?(Hash) ? args.pop : {}
       unescaped_url = args.shift || sitemap_index_url
-      index_url = CGI.escape(unescaped_url)
+      index_url = URI.encode_www_form_component(unescaped_url)
 
       output("\n")
       output("Pinging with URL '#{unescaped_url}':")

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'uri'
 
 RSpec.describe SitemapGenerator::LinkSet do
   let(:default_host) { 'http://example.com' }
@@ -156,7 +157,7 @@ RSpec.describe SitemapGenerator::LinkSet do
     it 'should use the sitemap index url provided' do
       index_url = 'http://example.com/index.xml'
       ls = SitemapGenerator::LinkSet.new(:search_engines => { :google => 'http://google.com/?url=%s' })
-      request = stub_request(:get, "http://google.com/?url=#{CGI.escape(index_url)}")
+      request = stub_request(:get, "http://google.com/?url=#{URI.encode_www_form_component(index_url)}")
       ls.ping_search_engines(index_url)
       expect(request).to have_been_requested
     end
@@ -166,7 +167,7 @@ RSpec.describe SitemapGenerator::LinkSet do
         :default_host => default_host,
         :search_engines => { :google => 'http://google.com/?url=%s' })
       index_url = ls.sitemap_index_url
-      request = stub_request(:get, "http://google.com/?url=#{CGI.escape(index_url)}")
+      request = stub_request(:get, "http://google.com/?url=#{URI.encode_www_form_component(index_url)}")
       ls.ping_search_engines
       expect(request).to have_been_requested
     end

--- a/spec/sitemap_generator/sitemap_generator_spec.rb
+++ b/spec/sitemap_generator/sitemap_generator_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require 'cgi'
+require 'uri'
 
 class Holder
   class << self
@@ -324,7 +324,7 @@ RSpec.describe 'SitemapGenerator' do
     }
 
     let!(:request) do
-      stub_request(:get, "http://google.com/?url=#{CGI.escape('http://example.com/sitemap.xml.gz')}")
+      stub_request(:get, "http://google.com/?url=#{URI.encode_www_form_component('http://example.com/sitemap.xml.gz')}")
     end
 
     before do


### PR DESCRIPTION
Ruby 4 no longer includes the `cgi` gem by default. This means that sitemap_generator fails to run on Ruby 4 with an error like this:

```
LoadError: cannot load such file -- cgi/session (LoadError)
sitemap_generator-6.3.0/lib/sitemap_generator/link_set.rb:282:in 'SitemapGenerator::LinkSet#ping_search_engines'
```

There are two possible fixes:

1. Add `cgi` as an explicit gem dependency in `sitemap_generator.gemspec`.
2. Remove our usage of `CGI.escape`.

This PR removes the CGI dependency by replacing `CGI.escape` with the equivalent `URI.encode_www_form_component` that is built into Ruby.