### PR TITLE
Improve Sitemap method-missing implementation

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -41,10 +41,6 @@ module SitemapGenerator
 
     # Lazy-initialize the LinkSet instance
     Sitemap = (Class.new do
-      def respond_to?(name, include_private = false)
-        (@link_set ||= reset!).respond_to?(name, include_private)
-      end
-
       # Use a new LinkSet instance
       def reset!
         @link_set = LinkSet.new
@@ -54,6 +50,10 @@ module SitemapGenerator
 
       def method_missing(*args, &block)
         (@link_set ||= reset!).send(*args, &block)
+      end
+
+      def respond_to_missing?(name, include_private = false)
+        (@link_set ||= reset!).respond_to?(name, include_private)
       end
     end).new
   end

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -40,7 +40,7 @@ module SitemapGenerator
     }
 
     # Lazy-initialize the LinkSet instance
-    Sitemap = (Class.new do
+    Sitemap = (Config = Class.new do
       # Use a new LinkSet instance
       def reset!
         @link_set = LinkSet.new

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -41,10 +41,6 @@ module SitemapGenerator
 
     # Lazy-initialize the LinkSet instance
     Sitemap = (Class.new do
-      def method_missing(*args, &block)
-        (@link_set ||= reset!).send(*args, &block)
-      end
-
       def respond_to?(name, include_private = false)
         (@link_set ||= reset!).respond_to?(name, include_private)
       end
@@ -52,6 +48,12 @@ module SitemapGenerator
       # Use a new LinkSet instance
       def reset!
         @link_set = LinkSet.new
+      end
+
+      private
+
+      def method_missing(*args, &block)
+        (@link_set ||= reset!).send(*args, &block)
       end
     end).new
   end

--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -48,12 +48,13 @@ module SitemapGenerator
 
       private
 
-      def method_missing(*args, &block)
-        (@link_set ||= reset!).send(*args, &block)
+      def method_missing(name, *args, &block)
+        @link_set ||= reset!
+        @link_set.respond_to?(name, true) ? @link_set.__send__(name, *args, &block) : super
       end
 
       def respond_to_missing?(name, include_private = false)
-        (@link_set ||= reset!).respond_to?(name, include_private)
+        (@link_set ||= reset!).respond_to?(name, include_private) || super
       end
     end).new
   end

--- a/sitemap_generator.gemspec
+++ b/sitemap_generator.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.name = 'sitemap_generator'
   s.version = File.read('VERSION').chomp
   s.platform = Gem::Platform::RUBY
+  s.required_ruby_version = '>= 2.6'
   s.authors = ['Karl Varga']
   s.email = 'kjvarga@gmail.com'
   s.homepage = 'https://github.com/kjvarga/sitemap_generator'

--- a/spec/sitemap_generator/sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemap_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe SitemapGenerator::Sitemap do
+  subject { described_class }
+
+  describe "method missing" do
+    it "should not be public" do
+      expect(subject.methods).to_not include :method_missing
+    end
+  end
+end

--- a/spec/sitemap_generator/sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemap_spec.rb
@@ -11,5 +11,23 @@ RSpec.describe SitemapGenerator::Sitemap do
     it "responds properly" do
       expect(subject.method :default_host).to be_a Method
     end
+
+    it "respects inheritance" do
+      subject.class.include Module.new {
+        def method_missing(*args)
+          :inherited
+        end
+        def respond_to_missing?(name, *)
+          name == :something_inherited
+        end
+      }
+
+      expect(subject).to respond_to :something_inherited
+      expect(subject.linkset_doesnt_know).to be :inherited
+    end
+
+    it "unconventionally delegates private (and protected) methods" do
+      expect { subject.options_for_group({}) }.to_not raise_error
+    end
   end
 end

--- a/spec/sitemap_generator/sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemap_spec.rb
@@ -7,5 +7,9 @@ RSpec.describe SitemapGenerator::Sitemap do
     it "should not be public" do
       expect(subject.methods).to_not include :method_missing
     end
+
+    it "responds properly" do
+      expect(subject.method :default_host).to be_a Method
+    end
   end
 end

--- a/spec/sitemap_generator/sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemap_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 RSpec.describe SitemapGenerator::Sitemap do
   subject { described_class }
 
+  it "has a class name" do
+    expect(subject.class.name).to match "SitemapGenerator::"
+  end
+
   describe "method missing" do
     it "should not be public" do
       expect(subject.methods).to_not include :method_missing


### PR DESCRIPTION
Fix up the implementation of method-missing for the SitemapGenerator::Sitemap parent class.

method missing implementations should:
- be private
- delegate unknowns to its ancestors
- override `respond_to_missing?`, not `respond_to?`

Also
- improve the debug-ability of this class by giving it a name.
- update the gemspec to properly report the required ruby version.
- use proper `__send__`, not `send`
- ~only delegate public methods so as to not break encapsulation and leak private methods~

Fixes #472 