### PR TITLE
Fix broken specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gemspec
 gem 'appraisal', git: 'https://github.com/thoughtbot/appraisal.git'
 gem 'aws-sdk-core'
 gem 'aws-sdk-s3'
+gem 'byebug'
 gem 'combustion'
 gem 'fog-aws'
 gem 'google-cloud-storage'
@@ -18,16 +19,12 @@ gem 'rspec_junit_formatter'
 gem 'rspec-rails'
 gem 'simplecov'
 gem 'sqlite3', '~> 2.1.0'
-gem 'webmock'
+gem 'webmock', require: 'webmock/rspec'
 
 if RUBY_VERSION.match?(/2.5.*/)
   gem 'nokogiri', '1.12.5'
 else
   gem 'nokogiri'
-end
-
-group :test do
-  gem 'byebug'
 end
 
 # Dev tools / linter

--- a/gemfiles/rails_6.0.gemfile
+++ b/gemfiles/rails_6.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,16 +16,12 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 1.5.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 install_if -> { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0") } do
   gem "drb"

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,16 +16,12 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 1.5.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 install_if -> { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0") } do
   gem "drb"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,16 +16,12 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 1.5.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 install_if -> { Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.4.0") } do
   gem "drb"

--- a/gemfiles/rails_7.1.gemfile
+++ b/gemfiles/rails_7.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,15 +16,11 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 1.5.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 gemspec path: "../"

--- a/gemfiles/rails_7.2.gemfile
+++ b/gemfiles/rails_7.2.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,15 +16,11 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 1.5.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,15 +16,11 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 2.1.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 gemspec path: "../"

--- a/gemfiles/rails_8.1.gemfile
+++ b/gemfiles/rails_8.1.gemfile
@@ -5,6 +5,7 @@ source "https://rubygems.org"
 gem "appraisal", git: "https://github.com/thoughtbot/appraisal.git"
 gem "aws-sdk-core"
 gem "aws-sdk-s3"
+gem "byebug"
 gem "combustion"
 gem "fog-aws"
 gem "google-cloud-storage"
@@ -15,15 +16,11 @@ gem "rspec_junit_formatter"
 gem "rspec-rails"
 gem "simplecov"
 gem "sqlite3", "~> 2.1.0"
-gem "webmock"
+gem "webmock", require: "webmock/rspec"
 gem "nokogiri"
 gem "rubocop", require: false
 gem "rubocop-performance", require: false
 gem "rubocop-rake", require: false
 gem "rubocop-rspec", require: false
-
-group :test do
-  gem "byebug"
-end
 
 gemspec path: "../"

--- a/spec/sitemap_generator/interpreter_spec.rb
+++ b/spec/sitemap_generator/interpreter_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'sitemap_generator/interpreter'
 
 RSpec.describe SitemapGenerator::Interpreter do
+  include SitemapHelpers
+
   let(:link_set)    { SitemapGenerator::LinkSet.new }
   let(:interpreter) { SitemapGenerator::Interpreter.new(:link_set => link_set) }
 

--- a/spec/sitemap_generator/sitemap_generator_spec.rb
+++ b/spec/sitemap_generator/sitemap_generator_spec.rb
@@ -7,15 +7,9 @@ class Holder
   end
 end
 
-def with_max_links(num)
-  original = SitemapGenerator::Sitemap.max_sitemap_links
-  SitemapGenerator::Sitemap.max_sitemap_links = num
-  yield
-ensure
-  SitemapGenerator::Sitemap.max_sitemap_links = original
-end
-
 RSpec.describe 'SitemapGenerator' do
+  include SitemapHelpers
+
   describe 'reset!' do
     before do
       SitemapGenerator::Sitemap.default_host # Force initialization of the LinkSet

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,8 @@ SimpleCov.start do
 end
 
 # Load dev/test libs
+require 'bundler/setup'
+Bundler.require
 require 'byebug'
 require 'webmock/rspec'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ Bundler.require
 # Load support files
 require_relative 'support/file_macros'
 require_relative 'support/xml_macros'
+require_relative 'support/sitemap_helpers'
 
 # Configure webmock
 WebMock.disable_net_connect!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,9 @@
+# Load simplecov
+require 'simplecov'
+SimpleCov.start do
+  add_filter 'spec/'
+end
+
 # Load dev/test libs
 require 'byebug'
 require 'webmock/rspec'
@@ -5,12 +11,6 @@ require 'webmock/rspec'
 # Load support files
 require_relative 'support/file_macros'
 require_relative 'support/xml_macros'
-
-# Load simplecov
-require 'simplecov'
-SimpleCov.start do
-  add_filter 'spec/'
-end
 
 # Configure webmock
 WebMock.disable_net_connect!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,6 @@ end
 # Load dev/test libs
 require 'bundler/setup'
 Bundler.require
-require 'byebug'
-require 'webmock/rspec'
 
 # Load support files
 require_relative 'support/file_macros'

--- a/spec/support/sitemap_helpers.rb
+++ b/spec/support/sitemap_helpers.rb
@@ -1,0 +1,9 @@
+module SitemapHelpers
+  def with_max_links(num)
+    original = SitemapGenerator::Sitemap.max_sitemap_links
+    SitemapGenerator::Sitemap.max_sitemap_links = num
+    yield
+  ensure
+    SitemapGenerator::Sitemap.max_sitemap_links = original
+  end
+end


### PR DESCRIPTION
This resolves #475 by:
- loading all deps from Gemfile in the spec_helper
- extracting and properly including a helper module for the `with_max_links` helper


Additionally, it moves simplecov to the first require (which it must be, for coverage to be reported properly). It also eliminates the extraneous "test" bundler group, which wasn't even being used.


The "redundant" changes to the many gemfiles in this PR are the result of appraisal replicating the gemfile changes to all the generated gemfiles.