### PR TITLE
Simplify rake task hierarchy

### DIFF
--- a/lib/sitemap_generator/tasks.rb
+++ b/lib/sitemap_generator/tasks.rb
@@ -10,46 +10,32 @@ namespace :sitemap do
   # Require sitemap_generator only.  When installed as a plugin the require will fail, so in
   # that case, load the environment first.
   task :require do
-    begin
-      require 'sitemap_generator'
-    rescue LoadError => e
-      if defined?(Rails::VERSION)
-        Rake::Task['sitemap:require_environment'].invoke
-      else
-        raise e
-      end
-    end
-  end
-
-  # Require sitemap_generator after loading the Rails environment.  We still need the require
-  # in case we are installed as a gem and are setup to not automatically be required.
-  task :require_environment do
-    if defined?(Rails::VERSION)
-      Rake::Task['environment'].invoke
-    end
     require 'sitemap_generator'
   end
+  # In a Rails app, we need to boot Rails.
+  # Ensure gem is required in case it wasn't automatically loaded.
+  Rake::Task[:require].enhance([:environment]) if defined?(Rails)
 
   desc 'Install a default config/sitemap.rb file'
-  task install: ['sitemap:require'] do
+  task install: :require do
     SitemapGenerator::Utilities.install_sitemap_rb(verbose)
   end
 
   desc 'Delete all Sitemap files in public/ directory'
-  task clean: ['sitemap:require'] do
+  task clean: :require do
     SitemapGenerator::Utilities.clean_files
   end
 
   desc 'Generate sitemaps and ping search engines.'
-  task refresh: ['sitemap:create'] do
+  task refresh: :create do
     SitemapGenerator::Sitemap.ping_search_engines
   end
 
   desc "Generate sitemaps but don't ping search engines."
-  task 'refresh:no_ping' => ['sitemap:create']
+  task 'refresh:no_ping' => :create
 
   desc "Generate sitemaps but don't ping search engines.  Alias for refresh:no_ping."
-  task create: ['sitemap:require_environment'] do
+  task create: :require do
     SitemapGenerator::Interpreter.run(config_file: ENV['CONFIG_FILE'], verbose: verbose)
   end
 end


### PR DESCRIPTION
The require structure (both for loading the sitemap_generator gem, and for booting the Rails :environment), is legacy remainder from Rails plugins (pre Rails 4).

As the gem now only supports Rails 6+, we can simplify the task dependency tree quite a bit.

1. reduce the `sitemap:require` task down to _only_ requiring the 'sitemap_generator' gem.

This may be necessary in an app, where these tasks are loaded directly from the user's Rakefile via `require 'sitemap_generator/tasks'`.

2. Enhance this base `sitemap:require` task to boot the rails environment, but _only_ if Rails is defined. (ie, in a Rails app) With :environment added as a pre-req, it will run before the `sitemap:require` task. If in a Rails environment, and after the environment is booted, it is unlikely that we even need a require. (In most cases, the gem will already have been required by Rails using `Bundler.require`.) However, we cannot assume this is the case, as user's may omit the sitemap_generator gem from auto-requiring.

3. Simplify all pre-req references to depend on the base `sitemap:require` task (which would be conditionally enhanced if in a Rails app).