### PR TITLE
Enhance Rails railtie to respect existing rails configuration

### DIFF
--- a/integration/spec/sitemap_generator/railtie_spec.rb
+++ b/integration/spec/sitemap_generator/railtie_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+
+RSpec.describe "SitemapGenerator::Railtie" do
+  let(:app) { Rails.application }
+  let(:config) { app.config }
+  let(:initializers) { app.initializers.index_by(&:name) }
+
+  it "adds a top-level configuration namespace" do
+    expect(config.sitemap).to be_a ActiveSupport::OrderedOptions
+  end
+
+  after { config.sitemap.clear }
+
+  describe "set_configs initializer" do
+    subject(:initializer) { initializers["sitemap_generator.set_configs"] }
+
+    describe ".default_host" do
+      after { app.routes.default_url_options = config.action_controller.default_url_options = {} }
+
+      it "ignores Rails if set directly" do
+        app.routes.default_url_options = { host: "from_routes.test" }
+        config.sitemap.default_host = "http://custom.test"
+
+        initializer.run(app)
+
+        expect(config.sitemap.default_host).to eq "http://custom.test"
+      end
+
+      it "is inferred from Rails' routes default_url_options" do
+        app.routes.default_url_options = { host: "from_routes.test" }
+
+        initializer.run(app)
+
+        expect(config.sitemap.default_host).to eq "http://from_routes.test"
+      end
+
+      it "falls back to action_mailer, action_controller, and active_job" do
+        config.action_controller.default_url_options = { host: "from_action_controller.test" }
+
+        initializer.run(app)
+
+        expect(config.sitemap.default_host).to eq "http://from_action_controller.test"
+      end
+
+      it "doesn't construct a default_host if missing :host" do
+        config.action_controller.default_url_options = { trailing_slash: true }
+
+        initializer.run(app)
+
+        expect(config.sitemap.default_host).to be_nil
+      end
+    end
+
+    describe ".sitemaps_host" do
+      after { config.asset_host = config.action_controller.asset_host = nil }
+
+      it "can be set directly" do
+        config.action_controller.asset_host = "http://from_action_controller.test"
+        config.sitemap.sitemaps_host = "http://custom.test"
+
+        initializer.run(app)
+
+        expect(config.sitemap.sitemaps_host).to eq "http://custom.test"
+      end
+
+      it "is inferred from action_controller/assets_host" do
+        config.action_controller.asset_host = "http://from_action_controller.test"
+
+        initializer.run(app)
+
+        expect(config.sitemap.sitemaps_host).to eq "http://from_action_controller.test"
+      end
+
+      it "doesn't accept procs" do
+        config.action_controller.asset_host = -> { "dynamically construct hsot" }
+
+        initializer.run(app)
+
+        expect(config.sitemap.sitemaps_host).to be_nil
+      end
+    end
+
+    describe ".compress" do
+      # config.assets provided by Propshaft or Sprockets
+      before { config.assets = ActiveSupport::OrderedOptions[{gzip: true}] }
+      after { config.assets = nil }
+
+      it "is inferred from config.assets.gzip" do
+        initializer.run(app)
+
+        expect(config.sitemap.compress).to be true
+      end
+
+      it "can be set directly (nil != false)" do
+        config.sitemap.compress = false
+
+        initializer.run(app)
+
+        expect(config.sitemap.compress).to be false
+      end
+    end
+
+    describe ".public_path" do
+      after { app.paths["public"] = "public" }
+
+      it "can be set directly" do
+        config.sitemap.public_path = "custom"
+
+        initializer.run(app)
+
+        expect(config.sitemap.public_path).to eq "custom"
+      end
+
+      it "is inferred from Rails paths" do
+        app.paths["public"].unshift "inferred"
+
+        initializer.run(app)
+
+        expect(config.sitemap.public_path).to match "/inferred"
+      end
+    end
+  end
+end

--- a/integration/spec/sitemap_generator/railtie_spec.rb
+++ b/integration/spec/sitemap_generator/railtie_spec.rb
@@ -120,4 +120,26 @@ RSpec.describe "SitemapGenerator::Railtie" do
       end
     end
   end
+
+  describe "config_file initializer" do
+    subject(:initializer) { initializers["sitemap_generator.config_file"] }
+
+    after { ENV.delete "CONFIG_FILE" }
+
+    it "sets CONFIG_FILE" do
+      config.sitemap.config_file = "custom.rb"
+
+      expect { initializer.run(app) }
+        .to change { ENV["CONFIG_FILE"] }.to("custom.rb")
+        .and change(config, :sitemap).from have_key(:config_file)
+    end
+
+    it "does not override CONFIG_FILE" do
+      ENV["CONFIG_FILE"] = "existing.rb"
+      config.sitemap.config_file = "override.rb"
+
+      expect { initializer.run(app) }
+        .to_not change { ENV["CONFIG_FILE"] }.from("existing.rb")
+    end
+  end
 end

--- a/integration/spec/sitemap_generator/tasks_spec.rb
+++ b/integration/spec/sitemap_generator/tasks_spec.rb
@@ -69,6 +69,8 @@ RSpec.describe "SitemapGenerator" do
     end
   end
 
+  # This group of tests needs reworked.
+  # They fail if rails app is reloaded or prepare hooks are re-run.
   describe "generate sitemap with normal config" do
     before :all do
       SitemapGenerator::Sitemap.reset!

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -10,7 +10,6 @@ module SitemapGenerator
     end
 
     # Recognize existing Rails options as defaults for config.sitemap.*
-    # Then, after_initialize, "compile" them onto the SitemapGenerator classes.
     initializer 'sitemap_generator.set_configs' do |app|
       # routes.default_url_options takes precedence, falling back to configs
       url_opts = (app.default_url_options || {})
@@ -31,11 +30,14 @@ module SitemapGenerator
 
       config.sitemap.public_path ||= app.paths['public'].first
 
-      config.after_initialize do # TODO: ActiveSupport.on_load(:sitemap_generator)
-        config.sitemap.except(:adapter).each do |k, v|
-          SitemapGenerator::Sitemap.send("#{k}=", v)
+      # "Compile" config.sitemap options onto the Sitemap class.
+      config.after_initialize do
+        ActiveSupport.on_load(:sitemap_generator, yield: true) do |sitemap|
+          config.sitemap.except(:adapter).each { |k, v| sitemap.public_send("#{k}=", v) }
         end
       end
     end
   end
+
+  ActiveSupport.run_load_hooks(:sitemap_generator, Sitemap)
 end

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -45,6 +45,16 @@ module SitemapGenerator
         ENV['CONFIG_FILE'] = config_file
       end
     end
+
+    # Allow lazily setting the adapter class without forcing an autoload.
+    # (ie. string or symbol name; or Callable (proc/lambda/etc))
+    initializer 'sitemap_generator.adapter' do |app|
+      config.to_prepare do
+        ActiveSupport.on_load(:sitemap_generator) do
+          self.adapter = Utilities.find_adapter app.config.sitemap.adapter
+        end
+      end
+    end
   end
 
   ActiveSupport.run_load_hooks(:sitemap_generator, Sitemap)

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -2,8 +2,40 @@
 
 module SitemapGenerator
   class Railtie < Rails::Railtie
+    # Top level options object to namespace all settings
+    config.sitemap = ActiveSupport::OrderedOptions.new
+
     rake_tasks do
       load 'tasks/sitemap_generator_tasks.rake'
+    end
+
+    # Recognize existing Rails options as defaults for config.sitemap.*
+    # Then, after_initialize, "compile" them onto the SitemapGenerator classes.
+    initializer 'sitemap_generator.set_configs' do |app|
+      # routes.default_url_options takes precedence, falling back to configs
+      url_opts = (app.default_url_options || {})
+                 .with_defaults(config.try(:action_controller).try(:default_url_options) || {})
+                 .with_defaults(config.try(:action_mailer).try(:default_url_options) || {})
+                 .with_defaults(config.try(:active_job).try(:default_url_options) || {})
+
+      config.sitemap.default_host ||= ActionDispatch::Http::URL.full_url_for(url_opts) if url_opts.key?(:host)
+
+      # Rails defaults action_controller.asset_host and action_mailer.asset_host
+      # to the top-level config.asset_host so we get that for free here.
+      config.sitemap.sitemaps_host ||= [
+        config.try(:action_controller).try(:asset_host),
+        config.try(:action_mailer).try(:asset_host)
+      ].grep(String).first
+
+      config.sitemap.compress = config.try(:assets).try(:gzip) if config.sitemap.compress.nil?
+
+      config.sitemap.public_path ||= app.paths['public'].first
+
+      config.after_initialize do # TODO: ActiveSupport.on_load(:sitemap_generator)
+        config.sitemap.except(:adapter).each do |k, v|
+          SitemapGenerator::Sitemap.send("#{k}=", v)
+        end
+      end
     end
   end
 end

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -37,6 +37,14 @@ module SitemapGenerator
         end
       end
     end
+
+    # Allow setting the CONFIG_FILE without relying on env var;
+    # (e.g in config/application or environments/*.rb)
+    initializer 'sitemap_generator.config_file' do
+      if (config_file = config.sitemap.delete(:config_file).presence) && ENV['CONFIG_FILE'].blank?
+        ENV['CONFIG_FILE'] = config_file
+      end
+    end
   end
 
   ActiveSupport.run_load_hooks(:sitemap_generator, Sitemap)

--- a/lib/sitemap_generator/utilities.rb
+++ b/lib/sitemap_generator/utilities.rb
@@ -180,5 +180,29 @@ module SitemapGenerator
     def bytesize(string)
       string.respond_to?(:bytesize) ? string.bytesize : string.length
     end
+
+    # Looks up an adapter from various sources:
+    # 1. symbol/string names are camelized and constantized
+    #   - :fog becomes SitemapGenerator::FogAdapter
+    #   - 'external/adapter_class' becomes External::AdapterClass
+    # 2. classes are instantiated
+    # 3. callables (procs, lambdas, #call) are "called"
+    # All steps recurse, so a proc could return a string that names a class that is instantiated.
+    #
+    # This method is used by the Rails railtie and as such,
+    # safely depends on ActiveSupport::Inflector.
+    def find_adapter(candidate)
+      if candidate.is_a?(Symbol) || candidate.is_a?(String)
+        candidate.to_s.camelize.then { |name|
+          "SitemapGenerator::#{name}Adapter".safe_constantize || name.safe_constantize
+        }.then { |c| find_adapter(c) }
+      elsif candidate.respond_to?(:new)
+        find_adapter candidate.new
+      elsif candidate.respond_to?(:call)
+        find_adapter candidate.call
+      else
+        candidate
+      end
+    end
   end
 end

--- a/spec/sitemap_generator/utilities_spec.rb
+++ b/spec/sitemap_generator/utilities_spec.rb
@@ -100,4 +100,47 @@ RSpec.describe SitemapGenerator::Utilities do
       expect(SitemapGenerator::Utilities.ellipsis('aaa', 1)).to eq('...')
     end
   end
+
+  describe 'find_adapter' do
+    require 'active_support/core_ext/string/inflections'
+
+    context 'when candidate is an adapter (#write)' do
+      let(:candidate) { SitemapGenerator::FileAdapter.new }
+      it "returns the same candidate" do
+        expect(subject.find_adapter candidate).to be candidate
+      end
+    end
+
+    context 'when candidate is a callable (proc, lambda, #call)' do
+      it "invokes call and returns that" do
+        expect(subject.find_adapter -> { SitemapGenerator::FileAdapter.new }).to be_a SitemapGenerator::FileAdapter
+      end
+
+      it "recurses on the return" do
+        expect(subject.find_adapter -> { SitemapGenerator::FileAdapter }).to be_a SitemapGenerator::FileAdapter
+        expect(subject.find_adapter -> { :file }).to be_a SitemapGenerator::FileAdapter
+      end
+    end
+
+    context 'when candidate is a class (#new)' do
+      it "instantiates the class" do
+        expect(subject.find_adapter SitemapGenerator::FileAdapter).to be_a SitemapGenerator::FileAdapter
+      end
+    end
+
+    context 'when candidate is a class name' do
+      it "constantizes" do
+        expect(subject.find_adapter :file).to be_a SitemapGenerator::FileAdapter
+        expect(subject.find_adapter "file").to be_a SitemapGenerator::FileAdapter
+        expect(subject.find_adapter 'sitemap_generator/file_adapter').to be_a SitemapGenerator::FileAdapter
+      end
+    end
+
+    context 'when candidate is anything else' do
+      let(:candidate) { double }
+      it "returns the same candidate" do
+        expect(subject.find_adapter candidate).to be candidate
+      end
+    end
+  end
 end


### PR DESCRIPTION
Presently, the rails integration serves only to load the rake tasks "automatically". But there is a lot of configuration of Sitemap that is effectively duplicated (or can be inferred) from ones Rails app itself.

1. `default_host` can be constructed from `default_url_options`
2. `sitemaps_host` is very likely the same as `config.asset_host`
3. `compress` should probably match ones setting for `assets.gzip`
4. `public_path` should use Rails' `public_path`

(additional settings could be added here. For example, #355 )

## Railtie gains `config.sitemap.*`

So this PR adds `config.sitemap` (a Rails `OrderedOptions` object the same as all other Rails `config.*` objects). This gives the ability to set sitemap options in `config/application.rb` or `config/environments/*.rb` files. Doing so allows any environment-dependent options to be static in the appropriate environment config file; and eliminates brittle `Rails.env`-based branching logic in sitemap.rb itself. (This is also more idiomatic for railties.) As a secondary benefit, this allows the config/sitemap.rb file to be focused on the sitemap _content_ and not on general configuration.

## Sitemap options inferred from Rails

Now that we have an idiomatic railtie config, we can infer reasonable defaults _from the Rails app_. Notably, these are only _defaults_. Any explicit setting on `config.sitemap.*` takes precedence over the inferred default. Additionally, directly setting a value on `SitemapGenerator::Sitemap.*` as before takes precedence even over the `config.sitemap.*` values.

## Allow setting config_file via config.sitemap.config_file instead of CONFIG_FILE

Another benefit of the railtie configuration is the ability to control the `config_file` setting via configuration, instead of an environment variable. This gives one the ability to have different sitemap config files for various environments, without needing to set up awkward ENV variables in their scripts and tooling, automation, or host environments. (If the ENV var is _preferred_, it is still respected, so no capability is lost here.)

## Lazy-load sitemap adapters

And lastly, allow lazy loading of sitemap adapters. In a lazy-loaded environment (typically non-production), one shouldn't be forced to reference constants _directly_ as that triggers autoloading of the class (and potentially the entire gem) earlier in the initialization process that is desired.

Given the railtie configuration, one is now able to set the adapter by _name_. The name is then resolved to a class at initialization time instead of boot time.

The name resolution first looks for the class in the SitemapGenerator namespace (ie, :active_storage would find `SitemapGenerator::ActiveStorageAdapter`) but falls back to the global namespace if not found. (ie "org/custom_adapter" -> `Org::CustomAdapter`).

Additionally, for flexibility, this adapter resolution allows the setting to be a Callable (proc/lambda), a "factory" class/module pattern, etc. Basically, strings and symbols are constantized, callables are invoked, and classes are instantiated.

## Additional notes

Generally, this PR is extremely safe. For rails applications, these are new defaults that will be inferred from their Rails configuration but will not override existing settings.

From a code organization perspective, the adapter resolution logic was added to Utilities dumping ground. I'm not generally a fan of large "utilities" bags like this. But having the logic inlined into the railtie initializer is exceedingly difficult to test. (I believe the integration test suite has some problems that prevent the Rails reloader from being invoked, which is separately problematic.) To avoid tackling that problem here, the logic was moved into Utilities where it can be tested easily. A future refactor of the integration test setup (particularly the tasks_spec) would likely enable moving this logic back to the Railtie (probably as a `module_function`) and improve test confidence in the railtie.