### PR TITLE
ActiveStorageAdapter can upload multiple files

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -11,7 +11,7 @@ require 'sitemap_generator/sitemap_location'
 module SitemapGenerator
   autoload(:Interpreter,              'sitemap_generator/interpreter')
   autoload(:FileAdapter,              'sitemap_generator/adapters/file_adapter')
-  autoload(:ActiveStorageAdapter,     'sitemap_generator/adapters/active_storage_adapter') if defined?(::ActiveStorage)
+  autoload(:ActiveStorageAdapter,     'sitemap_generator/adapters/active_storage_adapter')
   autoload(:S3Adapter,                'sitemap_generator/adapters/s3_adapter')
   autoload(:AwsSdkAdapter,            'sitemap_generator/adapters/aws_sdk_adapter')
   autoload(:WaveAdapter,              'sitemap_generator/adapters/wave_adapter')

--- a/lib/sitemap_generator/adapters/active_storage_adapter.rb
+++ b/lib/sitemap_generator/adapters/active_storage_adapter.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+raise LoadError, <<~MSG unless defined?(ActiveStorage)
+  Error: 'ActiveStorage' is not defined.
+
+  Please `require 'active_storage'` - or another library that defines this class.
+MSG
+
 module SitemapGenerator
   # Class for uploading sitemaps to ActiveStorage.
   class ActiveStorageAdapter

--- a/lib/sitemap_generator/adapters/active_storage_adapter.rb
+++ b/lib/sitemap_generator/adapters/active_storage_adapter.rb
@@ -1,26 +1,38 @@
+# frozen_string_literal: true
+
 module SitemapGenerator
   # Class for uploading sitemaps to ActiveStorage.
   class ActiveStorageAdapter
-    attr_reader :key, :filename
-
-    def initialize key: :sitemap, filename: 'sitemap.xml.gz'
-      @key, @filename = key, filename
+    def initialize(prefix: nil)
+      @prefix = Pathname.new prefix.to_s
     end
 
     def write(location, raw_data)
-      SitemapGenerator::FileAdapter.new.write(location, raw_data)
+      FileAdapter.new.write(location, raw_data)
 
       ActiveStorage::Blob.transaction do
-        ActiveStorage::Blob.where(key: key).destroy_all
+        ActiveStorage::Blob.destroy_by(key: key(location))
 
         ActiveStorage::Blob.create_and_upload!(
-          key: key,
-          io: open(location.path, 'rb'),
-          filename: filename,
-          content_type: 'application/gzip',
+          key: key(location),
+          io: File.open(location.path),
+          filename: location.filename,
+          content_type: content_type(location),
           identify: false
         )
       end
+    end
+
+    private
+
+    def key(location)
+      (@prefix / location.path_in_public).to_s
+    end
+
+    def content_type(location)
+      # Using .gz matching to be consistent with FileAdapter
+      # but this logic is brittle and needs refactored
+      "application/#{location.path.match?(/.gz$/) ? 'gzip' : 'xml'}"
     end
   end
 end

--- a/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'sitemap_generator/adapters/active_storage_adapter'
 
 RSpec.describe 'SitemapGenerator::ActiveStorageAdapter' do
   subject(:adapter) { SitemapGenerator::ActiveStorageAdapter.new }

--- a/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
@@ -1,39 +1,72 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sitemap_generator/adapters/active_storage_adapter'
 
 RSpec.describe 'SitemapGenerator::ActiveStorageAdapter' do
-  let(:location) { SitemapGenerator::SitemapLocation.new }
-  let(:adapter)  { SitemapGenerator::ActiveStorageAdapter.new }
-  let(:fake_active_storage_blob) {
-    Class.new do
-      def self.transaction
-        yield
-      end
+  subject(:adapter) { SitemapGenerator::ActiveStorageAdapter.new }
 
-      def self.where(*args)
-        FakeScope.new
-      end
-
-      def self.create_and_upload!(**kwargs)
-        'ActiveStorage::Blob'
-      end
-
-      class FakeScope
-        def destroy_all
-          true
-        end
-      end
-    end
-  }
-
-  before do
-    stub_const('ActiveStorage::Blob', fake_active_storage_blob)
+  let!(:active_storage) do
+    class_double('ActiveStorage::Blob', destroy_by: true, create_and_upload!: nil)
+      .tap { |blob| allow(blob).to receive(:transaction).and_yield }
+      .as_stubbed_const
   end
 
   describe 'write' do
-    it 'should create an ActiveStorage::Blob record' do
-      expect(location).to receive(:filename).and_return('sitemap.xml.gz').at_least(2).times
-      expect(adapter.write(location, 'data')).to eq 'ActiveStorage::Blob'
+    let(:location) do
+      SitemapGenerator::SitemapLocation.new(
+        filename: 'custom.xml',
+        sitemaps_path: 'some_path'
+      )
+    end
+
+    it 'creates an ActiveStorage::Blob record' do
+      adapter.write(location, 'data')
+
+      expect(active_storage).to have_received(:create_and_upload!)
+    end
+
+    it 'gets key and filename from the sitemap_location' do
+      adapter.write(location, 'data')
+
+      expect(active_storage).to have_received(:create_and_upload!)
+        .with(include(key: 'some_path/custom.xml', filename: 'custom.xml'))
+    end
+
+    # Ideally, this would be driven by the location or namer collaborators,
+    # but it's all rather murky at the moment. filename extension is what
+    # drives compression in FileAdapter, so consistency wins
+    context 'with a gzipped file' do
+      let(:location) { SitemapGenerator::SitemapLocation.new(filename: 'custom.xml.gz') }
+
+      specify do
+        adapter.write(location, 'data')
+
+        expect(active_storage).to have_received(:create_and_upload!)
+          .with(include(content_type: 'application/gzip'))
+      end
+    end
+
+    context 'with a non-gzipped file' do
+      let(:location) { SitemapGenerator::SitemapLocation.new(filename: 'custom.xml') }
+
+      specify do
+        adapter.write(location, 'data')
+
+        expect(active_storage).to have_received(:create_and_upload!)
+          .with(include(content_type: 'application/xml'))
+      end
+    end
+
+    context 'with a custom prefix for segmenting from other blobs' do
+      subject(:adapter) { SitemapGenerator::ActiveStorageAdapter.new(prefix: 'sitemaps') }
+
+      it 'prefixes only the key' do
+        adapter.write(location, 'data')
+
+        expect(active_storage).to have_received(:create_and_upload!)
+          .with(include(key: 'sitemaps/some_path/custom.xml', filename: 'custom.xml'))
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #479 

- **Rework ActiveStorageAdapter to handle multiple files**
  The adapter must be able to handle multiple files (for writing sitemaps
  that are split due to size, as well as the resulting index). This means
  the adapter must derive the filename and key (as well as content type)
  from the `#write` location argument instead of being fixed at
  instantiation.
  
  This allows the same instance of an adapter to write multiple
  differently-named files, and even of different content types. It also
  adds the ability to customize a prefix, which may be necessary to avoid
  conflicts in ones storage bucket.
  

- **Autoload shouldn't be conditional**
  The autoload needs to be unconditional because ActiveStorage may be
  available when the _adapter_ is even if it's not available when the
  sitemap_generator is loaded. (That is the point of autoloads, after all.
  To allow delayed and potentially unused loading.)
  