### PR TITLE
sitemaps_host handles missing protocol

### DIFF
--- a/integration/spec/sitemap_generator/railtie_spec.rb
+++ b/integration/spec/sitemap_generator/railtie_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "SitemapGenerator::Railtie" do
       end
 
       it "doesn't construct a default_host if missing :host" do
-        config.action_controller.default_url_options = { trailing_slash: true }
+        config.action_controller.default_url_options = { host: "", trailing_slash: true }
 
         initializer.run(app)
 

--- a/integration/spec/sitemap_generator/railtie_spec.rb
+++ b/integration/spec/sitemap_generator/railtie_spec.rb
@@ -49,6 +49,14 @@ RSpec.describe "SitemapGenerator::Railtie" do
 
         expect(config.sitemap.default_host).to be_nil
       end
+
+      it "infers protocol from Rails (respects force_ssl)" do
+        config.action_controller.default_url_options = { host: "example.test" }
+
+        initializer.run(app)
+
+        expect(config.sitemap.default_host).to eq "http://example.test"
+      end
     end
 
     describe ".sitemaps_host" do
@@ -77,6 +85,14 @@ RSpec.describe "SitemapGenerator::Railtie" do
         initializer.run(app)
 
         expect(config.sitemap.sitemaps_host).to be_nil
+      end
+
+      it "infers protocol from Rails (respects force_ssl)" do
+        config.action_controller.asset_host = "example.test"
+
+        initializer.run(app)
+
+        expect(config.sitemap.sitemaps_host).to eq "http://example.test"
       end
     end
 

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -22,8 +22,8 @@ module SitemapGenerator
       # Rails defaults action_controller.asset_host and action_mailer.asset_host
       # to the top-level config.asset_host so we get that for free here.
       config.sitemap.sitemaps_host ||= [
-        config.try(:action_controller).try(:asset_host),
-        config.try(:action_mailer).try(:asset_host)
+        config.try(:action_mailer).try(:asset_host),
+        config.try(:action_controller).try(:asset_host)
       ].grep(String).first
 
       config.sitemap.compress = config.try(:assets).try(:gzip) if config.sitemap.compress.nil?

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -17,14 +17,18 @@ module SitemapGenerator
                  .with_defaults(config.try(:action_mailer).try(:default_url_options) || {})
                  .with_defaults(config.try(:active_job).try(:default_url_options) || {})
 
+      # respects force_ssl if protocol is missing
       config.sitemap.default_host ||= ActionDispatch::Http::URL.full_url_for(url_opts) if url_opts[:host].present?
 
       # Rails defaults action_controller.asset_host and action_mailer.asset_host
       # to the top-level config.asset_host so we get that for free here.
-      config.sitemap.sitemaps_host ||= [
+      asset_opts ||= { host: [
         config.try(:action_mailer).try(:asset_host),
         config.try(:action_controller).try(:asset_host)
-      ].grep(String).compact_blank.first
+      ].grep(String).compact_blank.first }
+
+      # respects force_ssl if protocol is missing
+      config.sitemap.sitemaps_host ||= ActionDispatch::Http::URL.full_url_for(asset_opts) if asset_opts[:host].present?
 
       config.sitemap.compress = config.try(:assets).try(:gzip) if config.sitemap.compress.nil?
 

--- a/lib/sitemap_generator/railtie.rb
+++ b/lib/sitemap_generator/railtie.rb
@@ -17,14 +17,14 @@ module SitemapGenerator
                  .with_defaults(config.try(:action_mailer).try(:default_url_options) || {})
                  .with_defaults(config.try(:active_job).try(:default_url_options) || {})
 
-      config.sitemap.default_host ||= ActionDispatch::Http::URL.full_url_for(url_opts) if url_opts.key?(:host)
+      config.sitemap.default_host ||= ActionDispatch::Http::URL.full_url_for(url_opts) if url_opts[:host].present?
 
       # Rails defaults action_controller.asset_host and action_mailer.asset_host
       # to the top-level config.asset_host so we get that for free here.
       config.sitemap.sitemaps_host ||= [
         config.try(:action_mailer).try(:asset_host),
         config.try(:action_controller).try(:asset_host)
-      ].grep(String).first
+      ].grep(String).compact_blank.first
 
       config.sitemap.compress = config.try(:assets).try(:gzip) if config.sitemap.compress.nil?
 


### PR DESCRIPTION
We want the sitemaps_host to be derived from the Rails app's `asset_host`.

Both `action_controller.asset_host` and `action_mailer.asset_host` default their value from `config.asset_host`. ActionController does not require the asset_host to have a protocol, because it can infer the protocol from the request. ActionMailer's asset host _must_ have a protocol specified, because there is no request from which it can be inferred.

This means that if an app uses the top-level `config.asset_host` shortcut to set both action_controller and action_mailer's asset_host, then we can trust that it has a protocol. 

However, if the application sets them both independently (or if action_mailer.asset_host is not set at all!!), then we can _not_ trust that the asset_host (from action_controller) has a protocol.

So to ensure that the host we use for sitemaps_host _does_ have a protocol, we now run the inferred asset_host value through the `full_url_for` helper. This adds a protocol if it is missing; and as a bonus, respects `config.force_ssl` when adding said protocol (for determining http vs https).

In addition to this safety check, we also (for robustness) want to ensure that an empty host (`nil` or `""`) is inadvertently used in this helper. This would be a very unlikely scenario, but we already have to check for the `:host` key anyway; we might as well check for value presence.

And lastly, we flip the precedence order for sitemaps_host to respect the mailer configuration over the controller configuration. In the common case, these will be the same, but if they are different, we likely want the "more external facing" host as used by ActionMailer.

As before, all of this logic is only for determining the _default_ value for `config.sitemap.sitemaps_host`. Any explicit setting on the railtie config, or on `SitemapGenerator::Sitemap.sitemaps_host` will remain untouched by the railtie.

semi related: https://github.com/rails/rails/issues/49656