### PR TITLE
fix: restore sitemap generation on Ruby 2.x with global frozen-string-literal

### DIFF
--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -26,6 +26,9 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapLocation.new(opts) : opts
         @link_count = 0
         @news_count = 0
+        # The + prefix makes this string explicitly mutable. Ruby 2.x with
+        # --enable=frozen-string-literal freezes interpolated heredocs, and
+        # gsub! below requires a mutable string.
         @xml_wrapper_start = +<<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <urlset

--- a/lib/sitemap_generator/builder/sitemap_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_file.rb
@@ -26,7 +26,7 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapLocation.new(opts) : opts
         @link_count = 0
         @news_count = 0
-        @xml_wrapper_start = <<-HTML
+        @xml_wrapper_start = +<<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <urlset
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/lib/sitemap_generator/builder/sitemap_index_file.rb
+++ b/lib/sitemap_generator/builder/sitemap_index_file.rb
@@ -12,6 +12,9 @@ module SitemapGenerator
         @location = opts.is_a?(Hash) ? SitemapGenerator::SitemapIndexLocation.new(opts) : opts
         @link_count = 0
         @sitemaps_link_count = 0
+        # The + prefix makes this string explicitly mutable. Ruby 2.x with
+        # --enable=frozen-string-literal freezes interpolated heredocs, and
+        # gsub! below requires a mutable string.
         @xml_wrapper_start = +<<-HTML
           <?xml version="1.0" encoding="UTF-8"?>
             <sitemapindex


### PR DESCRIPTION
This PR fixes a FrozenError crash in `SitemapFile` that occurs when Ruby is run with `--enable=frozen-string-literal` globally (e.g. via `RUBYOPT`). On Ruby 2.6/2.7 this flag freezes interpolated heredocs — unlike the per-file `# frozen_string_literal: true` magic comment, which leaves interpolated strings mutable.

- Adds `+` prefix to the `@xml_wrapper_start` heredoc in `SitemapFile#initialize`, making it explicitly mutable before `gsub!` is called
- Matches the identical fix already applied to `SitemapIndexFile` in the same commit pattern as #456
- Only Ruby 2.6/2.7 users running with the global frozen-string flag are affected; default usage is unaffected