### PR TITLE
fix: use explicit 'bundle install --local' in build task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,7 +42,7 @@ task build: [:prepare] do
   sh 'mkdir -p pkg'
   sh "gem build #{gemspec_file}"
   sh "mv #{gem_file} pkg"
-  sh 'bundle --local'
+  sh 'bundle install --local'
 end
 
 desc 'Chmod all files to be world readable'


### PR DESCRIPTION
Bundler warns that bare `bundle` without a subcommand will stop running `bundle install` in a future version. Silences the warning produced during `rake release` by being explicit.