### PR TITLE
ci: add RuboCop job to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,22 @@ on:
     - cron: '0 4 1 * *'
 
 jobs:
+  rubocop:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+          bundler-cache: true
+
+      - name: RuboCop
+        run: bundle exec rubocop
+
   rspec:
     runs-on: ubuntu-latest
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - gemfiles/*
     - pkg/**/*
     - spec/**/*
+    - vendor/**/*
     - integration/bin/*
     - integration/spec/**/*
 


### PR DESCRIPTION
## Summary

Adds a `rubocop` job to the CI workflow that runs on every push and PR. The job uses Ruby 3.4 (latest stable) and runs independently of the rspec matrix so failures are surfaced quickly.

This is stacked on top of #492 which brings the codebase to 0 RuboCop offenses.

## Test plan

- [x] `bundle exec rubocop` → 0 offenses locally
- [x] CI passes on this PR (validates that #492 is clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)