### PR TITLE
fix: set content_type in S3Adapter upload to fog

### DIFF
--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -22,7 +22,7 @@ module SitemapGenerator
     #
     # Alternatively you can use an environment variable to configure each option (except `fog_storage_options`).
     # The environment variables have the same name but capitalized, e.g. `FOG_PATH_STYLE`.
-    def initialize(opts = {})
+    def initialize(opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
       @aws_access_key_id = opts[:aws_access_key_id] || ENV.fetch('AWS_ACCESS_KEY_ID', nil)
       @aws_secret_access_key = opts[:aws_secret_access_key] || ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
       @aws_session_token = opts[:aws_session_token] || ENV.fetch('AWS_SESSION_TOKEN', nil)
@@ -36,7 +36,7 @@ module SitemapGenerator
     end
 
     # Call with a SitemapLocation and string data
-    def write(location, raw_data)
+    def write(location, raw_data) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
 
       credentials = { provider: @fog_provider }
@@ -57,7 +57,8 @@ module SitemapGenerator
       directory.files.create(
         key: location.path_in_public,
         body: File.open(location.path),
-        public: @fog_public
+        public: @fog_public,
+        content_type: /\.gz$/.match?(location.path_in_public.to_s) ? 'application/x-gzip' : 'application/xml'
       )
     end
   end

--- a/lib/sitemap_generator/adapters/s3_adapter.rb
+++ b/lib/sitemap_generator/adapters/s3_adapter.rb
@@ -22,7 +22,7 @@ module SitemapGenerator
     #
     # Alternatively you can use an environment variable to configure each option (except `fog_storage_options`).
     # The environment variables have the same name but capitalized, e.g. `FOG_PATH_STYLE`.
-    def initialize(opts = {}) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+    def initialize(opts = {})
       @aws_access_key_id = opts[:aws_access_key_id] || ENV.fetch('AWS_ACCESS_KEY_ID', nil)
       @aws_secret_access_key = opts[:aws_secret_access_key] || ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
       @aws_session_token = opts[:aws_session_token] || ENV.fetch('AWS_SESSION_TOKEN', nil)
@@ -36,7 +36,7 @@ module SitemapGenerator
     end
 
     # Call with a SitemapLocation and string data
-    def write(location, raw_data) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+    def write(location, raw_data)
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
 
       credentials = { provider: @fog_provider }

--- a/spec/sitemap_generator/adapters/s3_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/s3_adapter_spec.rb
@@ -88,8 +88,39 @@ RSpec.describe SitemapGenerator::S3Adapter do
         body: instance_of(File),
         key: 'test/sitemap.xml.gz',
         public: false,
+        content_type: 'application/x-gzip',
       )
       adapter.write(location, 'payload')
+    end
+
+    context 'when the path ends in .gz' do
+      it 'sets content_type to application/x-gzip' do
+        expect(Fog::Storage).to receive(:new).and_return(directories)
+        expect(directory.files).to receive(:create).with(
+          hash_including(content_type: 'application/x-gzip')
+        )
+        adapter.write(location, 'payload')
+      end
+    end
+
+    context 'when the path ends in .xml' do
+      let(:location) do
+        SitemapGenerator::SitemapLocation.new(
+          namer: SitemapGenerator::SimpleNamer.new(:sitemap),
+          public_path: 'tmp/',
+          sitemaps_path: 'test/',
+          host: 'http://example.com/',
+          compress: false
+        )
+      end
+
+      it 'sets content_type to application/xml' do
+        expect(Fog::Storage).to receive(:new).and_return(directories)
+        expect(directory.files).to receive(:create).with(
+          hash_including(content_type: 'application/xml')
+        )
+        adapter.write(location, 'payload')
+      end
     end
   end
 end

--- a/spec/sitemap_generator/adapters/s3_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/s3_adapter_spec.rb
@@ -93,16 +93,6 @@ RSpec.describe SitemapGenerator::S3Adapter do
       adapter.write(location, 'payload')
     end
 
-    context 'when the path ends in .gz' do
-      it 'sets content_type to application/x-gzip' do
-        expect(Fog::Storage).to receive(:new).and_return(directories)
-        expect(directory.files).to receive(:create).with(
-          hash_including(content_type: 'application/x-gzip')
-        )
-        adapter.write(location, 'payload')
-      end
-    end
-
     context 'when the path ends in .xml' do
       let(:location) do
         SitemapGenerator::SitemapLocation.new(


### PR DESCRIPTION
## Superseded by #495

The S3Adapter fix from this PR has been folded into #495, which also refactors the shared content-type logic onto `SitemapLocation#content_type`. Closing in favour of that PR.