### PR TITLE
chore: configure Copilot review behaviour and update test naming conventions

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,17 @@
 #!/bin/sh
-# Lint staged markdown files with mdl.
+# Lint staged files with mdl (markdown) and RuboCop (Ruby).
+exit_code=0
+
 md_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
-[ -z "$md_files" ] && exit 0
-echo "mdl: linting changed markdown files..."
-echo "$md_files" | xargs bundle exec mdl
+if [ -n "$md_files" ]; then
+  echo "mdl: linting changed markdown files..."
+  echo "$md_files" | xargs bundle exec mdl || exit_code=1
+fi
+
+rb_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.rb')
+if [ -n "$rb_files" ]; then
+  echo "rubocop: linting changed ruby files..."
+  echo "$rb_files" | xargs bundle exec rubocop || exit_code=1
+fi
+
+exit $exit_code

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Lint staged markdown files with mdl.
+md_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.md')
+[ -z "$md_files" ] && exit 0
+echo "mdl: linting changed markdown files..."
+echo "$md_files" | xargs bundle exec mdl

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+When reviewing a pull request, post suggestions as inline review comments on the PR — do not commit or push any changes. Describe what should change and why; do not apply the fix automatically.
+
+Only make code changes when explicitly asked to do so (e.g. "apply this", "go ahead and fix it"). When in doubt, comment and wait.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Local setup
+
+After cloning, activate the shared git hooks:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+This enables a pre-commit hook that runs `mdl` on any staged markdown files.
+
 ## Branch naming
 
 `<username>/<verb-first-kebab-description>` — e.g. `kvarga/fix-aws-upload-deprecation`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ After cloning, activate the shared git hooks:
 git config core.hooksPath .githooks
 ```
 
-This enables a pre-commit hook that runs `mdl` on any staged markdown files.
+This enables a pre-commit hook that runs `rubocop` on staged Ruby files and `mdl` on staged markdown files.
 
 ## Branch naming
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -68,12 +68,14 @@ Example skeleton:
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::MyClass do
-  subject(:my_class) { described_class.new }
+  let(:my_class) { described_class.new }
 
   describe '#my_method' do
+    subject(:my_method) { my_class.my_method }
+
     context 'when condition is true' do
       it 'returns the expected value' do
-        expect(my_class.my_method).to eq('expected')
+        expect(my_method).to eq('expected')
       end
     end
   end

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -56,8 +56,10 @@ cd integration && bundle exec rspec
 2. Add `require 'spec_helper'` at the top.
 3. Use `RSpec.describe SitemapGenerator::ClassName` at the top level.
 4. Use `describe '#method_name'` for instance methods, `describe '.method_name'` for class methods.
-5. Follow the `context`/`it` and `should` conventions in [docs/conventions.md](conventions.md#naming-conventions).
-6. For adapter tests that write files, use a temp path under `tmp/test/` and clean up in an `after` hook.
+5. Use `context 'when <condition>'` for branches; keep conditions out of `it` descriptions.
+6. Write `it` descriptions as declarative present-tense assertions — **never use "should"**. Say `it 'returns nil'`, not `it 'should return nil'`.
+7. See [docs/conventions.md](conventions.md#naming-conventions) for the full naming rules.
+8. For adapter tests that write files, use a temp path under `tmp/test/` and clean up in an `after` hook.
 
 Example skeleton:
 
@@ -67,12 +69,12 @@ Example skeleton:
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::MyClass do
-  let(:subject) { described_class.new }
+  subject(:my_class) { described_class.new }
 
   describe '#my_method' do
     context 'when condition is true' do
       it 'returns the expected value' do
-        expect(subject.my_method).to eq('expected')
+        expect(my_class.my_method).to eq('expected')
       end
     end
   end

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -52,13 +52,13 @@ cd integration && bundle exec rspec
 ## Adding a new test
 
 1. Create `spec/sitemap_generator/<matching_lib_path>_spec.rb` mirroring the lib path.
-2. Add `require 'spec_helper'` at the top.
-3. Use `RSpec.describe SitemapGenerator::ClassName` at the top level.
-4. Use `describe '#method_name'` for instance methods, `describe '.method_name'` for class methods.
-5. Use `context 'when <condition>'` for branches; keep conditions out of `it` descriptions.
-6. Write `it` descriptions as declarative present-tense assertions — **never use "should"**. Say `it 'returns nil'`, not `it 'should return nil'`.
-7. See [docs/conventions.md](conventions.md#naming-conventions) for the full naming rules.
-8. For adapter tests that write files, use a temp path under `tmp/test/` and clean up in an `after` hook.
+1. Add `require 'spec_helper'` at the top.
+1. Use `RSpec.describe SitemapGenerator::ClassName` at the top level.
+1. Use `describe '#method_name'` for instance methods, `describe '.method_name'` for class methods.
+1. Use `context 'when <condition>'` for branches; keep conditions out of `it` descriptions.
+1. Write `it` descriptions as declarative present-tense assertions — **never use "should"**. Say `it 'returns nil'`, not `it 'should return nil'`.
+1. See [docs/conventions.md](conventions.md#naming-conventions) for the full naming rules.
+1. For adapter tests that write files, use a temp path under `tmp/test/` and clean up in an `after` hook.
 
 Example skeleton:
 

--- a/lib/sitemap_generator/test_hook_violation.rb
+++ b/lib/sitemap_generator/test_hook_violation.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# missing frozen_string_literal comment — intentional RuboCop violation for hook test
+def hello
+  1
+end

--- a/lib/sitemap_generator/test_hook_violation.rb
+++ b/lib/sitemap_generator/test_hook_violation.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-# missing frozen_string_literal comment — intentional RuboCop violation for hook test
-def hello
-  1
-end


### PR DESCRIPTION
## Summary

- **Copilot instructions**: Add `.github/copilot-instructions.md` instructing Copilot to post inline PR review comments rather than auto-applying fixes. Changes are only made when explicitly asked.
- **Test naming conventions**: Update `docs/testing.md` to explicitly prohibit `should` in `it` descriptions. Descriptions must be declarative present-tense assertions (`it 'returns nil'`, not `it 'should return nil'`). Fixes the `let(:subject)` anti-pattern in the spec skeleton.

## Test plan

- [ ] Verify `.github/copilot-instructions.md` is visible in the repo and picked up by Copilot on future PR reviews
- [ ] Verify `docs/testing.md` reads clearly and the skeleton compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)