### PR TITLE
fix: clean_files respects configured path and removes uncompressed sitemaps

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -11,7 +11,7 @@ fi
 rb_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.rb')
 if [ -n "$rb_files" ]; then
   echo "rubocop: linting changed ruby files..."
-  echo "$rb_files" | xargs bundle exec rubocop || exit_code=1
+  echo "$rb_files" | xargs bundle exec rubocop --force-exclusion || exit_code=1
 fi
 
 exit $exit_code

--- a/integration/spec/sitemap_generator/tasks_spec.rb
+++ b/integration/spec/sitemap_generator/tasks_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 class Holder
@@ -6,13 +8,13 @@ class Holder
   end
 end
 
-RSpec.describe "SitemapGenerator" do
-  describe "reset!" do
-    before :each do
+RSpec.describe 'SitemapGenerator' do
+  describe 'reset!' do
+    before do
       SitemapGenerator::Sitemap.default_host # Force initialization of the LinkSet
     end
 
-    it "should set a new LinkSet instance" do
+    it 'sets a new LinkSet instance' do
       first = SitemapGenerator::Sitemap.instance_variable_get(:@link_set)
       expect(first).to be_a(SitemapGenerator::LinkSet)
       SitemapGenerator::Sitemap.reset!
@@ -22,54 +24,55 @@ RSpec.describe "SitemapGenerator" do
     end
   end
 
-  describe "app root" do
-    it "should be set to the Rails root" do
+  describe 'app root' do
+    it 'is set to the Rails root' do
       expect(SitemapGenerator.app.root.to_s).to eq(Rails.root.to_s)
     end
   end
 
-  describe "clean task" do
-    before :each do
+  describe 'clean task' do
+    before do
+      SitemapGenerator::Sitemap.reset!
       FileUtils.mkdir_p(rails_path('public/'))
       FileUtils.touch(rails_path('public/sitemap.xml.gz'))
     end
 
-    it "should delete the sitemaps" do
+    it 'deletes the sitemaps' do
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       Helpers.invoke_task('sitemap:clean')
       file_should_not_exist(rails_path('public/sitemap.xml.gz'))
     end
   end
 
-  describe "fresh install" do
-    before :each do
+  describe 'fresh install' do
+    before do
       delete_sitemap_file_from_rails_app
       Helpers.invoke_task('sitemap:install')
     end
 
-    it "should create config/sitemap.rb" do
+    it 'creates config/sitemap.rb' do
       file_should_exist(rails_path('config/sitemap.rb'))
     end
 
-    it "should create config/sitemap.rb matching template" do
+    it 'creates config/sitemap.rb matching template' do
       sitemap_template = SitemapGenerator.templates.template_path(:sitemap_sample)
       files_should_be_identical(rails_path('config/sitemap.rb'), sitemap_template)
     end
   end
 
-  describe "install multiple times" do
-    before :each do
+  describe 'install multiple times' do
+    before do
       copy_sitemap_file_to_rails_app(:create)
       Helpers.invoke_task('sitemap:install')
     end
 
-    it "should not overwrite config/sitemap.rb" do
+    it 'does not overwrite config/sitemap.rb' do
       sitemap_file = File.join(this_root, 'spec/files/sitemap.create.rb')
       files_should_be_identical(sitemap_file, rails_path('config/sitemap.rb'))
     end
   end
 
-  describe "generate sitemap with normal config" do
+  describe 'generate sitemap with normal config' do
     before :all do
       SitemapGenerator::Sitemap.reset!
       clean_sitemap_files_from_rails_app
@@ -77,36 +80,36 @@ RSpec.describe "SitemapGenerator" do
       with_max_links(10) { execute_sitemap_config }
     end
 
-    it "should create sitemaps" do
+    it 'creates sitemaps' do
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_exist(rails_path('public/sitemap1.xml.gz'))
       file_should_exist(rails_path('public/sitemap2.xml.gz'))
       file_should_not_exist(rails_path('public/sitemap3.xml.gz'))
     end
 
-    it "should have 13 links" do
+    it 'has 13 links' do
       expect(SitemapGenerator::Sitemap.link_count).to eq(13)
     end
 
-    it "index XML should validate" do
+    it 'index XML should validate' do
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'siteindex'
     end
 
-    it "sitemap XML should validate" do
+    it 'sitemap XML should validate' do
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap1.xml.gz'), 'sitemap'
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap2.xml.gz'), 'sitemap'
     end
 
-    it "index XML should not have excess whitespace" do
+    it 'index XML should not have excess whitespace' do
       gzipped_xml_file_should_have_minimal_whitespace rails_path('public/sitemap.xml.gz')
     end
 
-    it "sitemap XML should not have excess whitespace" do
+    it 'sitemap XML should not have excess whitespace' do
       gzipped_xml_file_should_have_minimal_whitespace rails_path('public/sitemap1.xml.gz')
     end
   end
 
-  describe "sitemap with groups" do
+  describe 'sitemap with groups' do
     before :all do
       SitemapGenerator::Sitemap.reset!
       clean_sitemap_files_from_rails_app
@@ -122,11 +125,12 @@ RSpec.describe "SitemapGenerator" do
         public/fr/new_sitemaps1.xml.gz
         public/fr/new_sitemaps2.xml.gz
         public/fr/new_sitemaps3.xml.gz
-        public/fr/new_sitemaps4.xml.gz]
+        public/fr/new_sitemaps4.xml.gz
+      ]
       @sitemaps = (@expected - %w[public/fr/new_sitemaps.xml.gz])
     end
 
-    it "should create sitemaps" do
+    it 'creates sitemaps' do
       @expected.each { |file| file_should_exist(rails_path(file)) }
       file_should_not_exist(rails_path('public/fr/new_sitemaps5.xml.gz'))
       file_should_not_exist(rails_path('public/en/xxx1.xml.gz'))
@@ -135,37 +139,37 @@ RSpec.describe "SitemapGenerator" do
       file_should_not_exist(rails_path('public/fr/def2.xml.gz'))
     end
 
-    it "should have 16 links" do
+    it 'has 16 links' do
       expect(SitemapGenerator::Sitemap.link_count).to eq(16)
     end
 
-    it "index XML should validate" do
+    it 'index XML should validate' do
       gzipped_xml_file_should_validate_against_schema rails_path('public/fr/new_sitemaps.xml.gz'), 'siteindex'
     end
 
-    it "index XML should not have excess whitespace" do
+    it 'index XML should not have excess whitespace' do
       gzipped_xml_file_should_have_minimal_whitespace rails_path('public/fr/new_sitemaps.xml.gz')
     end
 
-    it "sitemaps XML should validate" do
+    it 'sitemaps XML should validate' do
       @sitemaps.each { |file| gzipped_xml_file_should_validate_against_schema(rails_path(file), 'sitemap') }
     end
 
-    it "sitemap XML should not have excess whitespace" do
+    it 'sitemap XML should not have excess whitespace' do
       @sitemaps.each { |file| gzipped_xml_file_should_have_minimal_whitespace(rails_path(file)) }
     end
   end
 
-  describe "sitemap path" do
-    before :each do
+  describe 'sitemap path' do
+    before do
       clean_sitemap_files_from_rails_app
-      ::SitemapGenerator::Sitemap.reset!
-      ::SitemapGenerator::Sitemap.default_host = 'http://test.local'
-      ::SitemapGenerator::Sitemap.filename = 'sitemap'
+      SitemapGenerator::Sitemap.reset!
+      SitemapGenerator::Sitemap.default_host = 'http://test.local'
+      SitemapGenerator::Sitemap.filename = 'sitemap'
     end
 
-    it "should allow changing of the filename" do
-      ::SitemapGenerator::Sitemap.create(:filename => :geo_sitemap) do
+    it 'allows changing of the filename' do
+      SitemapGenerator::Sitemap.create(filename: :geo_sitemap) do
         add '/goerss'
         add '/kml'
       end
@@ -173,10 +177,10 @@ RSpec.describe "SitemapGenerator" do
       file_should_not_exist(rails_path('public/geo_sitemap1.xml.gz'))
     end
 
-    it "should support setting a sitemap path" do
+    it 'supports setting a sitemap path' do
       directory_should_not_exist(rails_path('public/sitemaps/'))
 
-      sm = ::SitemapGenerator::Sitemap
+      sm = SitemapGenerator::Sitemap
       sm.sitemaps_path = 'sitemaps/'
       sm.create do
         add '/'
@@ -187,10 +191,10 @@ RSpec.describe "SitemapGenerator" do
       file_should_not_exist(rails_path('public/sitemaps/sitemap1.xml.gz'))
     end
 
-    it "should support setting a deeply nested sitemap path" do
+    it 'supports setting a deeply nested sitemap path' do
       directory_should_not_exist(rails_path('public/sitemaps/deep/directory'))
 
-      sm = ::SitemapGenerator::Sitemap
+      sm = SitemapGenerator::Sitemap
       sm.sitemaps_path = 'sitemaps/deep/directory/'
       sm.create do
         add '/'
@@ -203,20 +207,20 @@ RSpec.describe "SitemapGenerator" do
     end
   end
 
-  describe "external dependencies" do
-    describe "rails" do
-      before :each do
+  describe 'external dependencies' do
+    describe 'rails' do
+      before do
         @rails = Rails
         Object.send(:remove_const, :Rails)
       end
 
-      after :each do
+      after do
         Object::Rails = @rails
       end
 
-      it "should work outside of Rails" do
+      it 'works outside of Rails' do
         expect(defined?(Rails)).to be_nil
-        expect { ::SitemapGenerator::LinkSet.new }.not_to raise_exception
+        expect { SitemapGenerator::LinkSet.new }.not_to raise_exception
       end
     end
   end

--- a/lib/sitemap_generator/utilities.rb
+++ b/lib/sitemap_generator/utilities.rb
@@ -28,7 +28,10 @@ module SitemapGenerator
 
     # Clean sitemap files in output directory.
     def clean_files
-      FileUtils.rm(Dir[SitemapGenerator.app.root + 'public/sitemap*.xml.gz']) # rubocop:disable Style/StringConcatenation
+      location = SitemapGenerator::Sitemap.sitemap_location
+      dir = location.directory
+      base = SitemapGenerator::Sitemap.filename.to_s
+      FileUtils.rm(Dir["#{dir}/#{base}*.xml.gz", "#{dir}/#{base}*.xml"])
     end
 
     # Validate all keys in a hash match *valid keys, raising ArgumentError on a

--- a/lib/sitemap_generator/utilities.rb
+++ b/lib/sitemap_generator/utilities.rb
@@ -31,7 +31,9 @@ module SitemapGenerator
       location = SitemapGenerator::Sitemap.sitemap_location
       dir = location.directory
       base = SitemapGenerator::Sitemap.filename.to_s
-      FileUtils.rm(Dir["#{dir}/#{base}*.xml.gz", "#{dir}/#{base}*.xml"])
+      return if base.empty?
+
+      FileUtils.rm(Dir[File.join(dir, "#{base}*.xml.gz"), File.join(dir, "#{base}*.xml")])
     end
 
     # Validate all keys in a hash match *valid keys, raising ArgumentError on a

--- a/spec/sitemap_generator/utilities_spec.rb
+++ b/spec/sitemap_generator/utilities_spec.rb
@@ -1,103 +1,110 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::Utilities do
-
   describe 'assert_valid_keys' do
-    it 'should raise error on invalid keys' do
-      expect {
-        SitemapGenerator::Utilities.assert_valid_keys({ :name => 'Rob', :years => '28' }, :name, :age)
-      }.to raise_exception(ArgumentError)
-      expect {
-        SitemapGenerator::Utilities.assert_valid_keys({ :name => 'Rob', :age => '28' }, 'name', 'age')
-      }.to raise_exception(ArgumentError)
+    it 'raises error on invalid keys' do
+      expect do
+        described_class.assert_valid_keys({ name: 'Rob', years: '28' }, :name, :age)
+      end.to raise_exception(ArgumentError)
+      expect do
+        described_class.assert_valid_keys({ name: 'Rob', age: '28' }, 'name', 'age')
+      end.to raise_exception(ArgumentError)
     end
 
-    it 'should not raise error on valid keys' do
-      expect {
-        SitemapGenerator::Utilities.assert_valid_keys({ :name => 'Rob', :age => '28' }, :name, :age)
-      }.not_to raise_exception
+    it 'does not raise error on valid keys' do
+      expect do
+        described_class.assert_valid_keys({ name: 'Rob', age: '28' }, :name, :age)
+      end.not_to raise_exception
 
-      expect {
-        SitemapGenerator::Utilities.assert_valid_keys({ :name => 'Rob' }, :name, :age)
-      }.not_to raise_exception
+      expect do
+        described_class.assert_valid_keys({ name: 'Rob' }, :name, :age)
+      end.not_to raise_exception
     end
   end
 
   describe 'titleize' do
-    it 'should titleize words and replace underscores' do
-      expect(SitemapGenerator::Utilities.titleize('google')).to eq('Google')
-      expect(SitemapGenerator::Utilities.titleize('amy_and_jon')).to eq('Amy And Jon')
+    it 'titleizes words and replace underscores' do
+      expect(described_class.titleize('google')).to eq('Google')
+      expect(described_class.titleize('amy_and_jon')).to eq('Amy And Jon')
     end
   end
 
   describe 'truthy?' do
-    it 'should be truthy' do
+    it 'is truthy' do
       ['1', 1, 't', 'true', true].each do |value|
-        expect(SitemapGenerator::Utilities.truthy?(value)).to be(true)
+        expect(described_class.truthy?(value)).to be(true)
       end
-      expect(SitemapGenerator::Utilities.truthy?(nil)).to be(false)
+      expect(described_class.truthy?(nil)).to be(false)
     end
   end
 
   describe 'falsy?' do
-    it 'should be falsy' do
+    it 'is falsy' do
       ['0', 0, 'f', 'false', false].each do |value|
-        expect(SitemapGenerator::Utilities.falsy?(value)).to be(true)
+        expect(described_class.falsy?(value)).to be(true)
       end
-      expect(SitemapGenerator::Utilities.falsy?(nil)).to be(false)
+      expect(described_class.falsy?(nil)).to be(false)
     end
   end
 
   describe 'as_array' do
-    it 'should return an array unchanged' do
-      expect(SitemapGenerator::Utilities.as_array([])).to eq([])
-      expect(SitemapGenerator::Utilities.as_array([1])).to eq([1])
-      expect(SitemapGenerator::Utilities.as_array([1,2,3])).to eq([1,2,3])
+    it 'returns an array unchanged' do
+      expect(described_class.as_array([])).to eq([])
+      expect(described_class.as_array([1])).to eq([1])
+      expect(described_class.as_array([1, 2, 3])).to eq([1, 2, 3])
     end
 
-    it 'should return empty array on nil' do
-      expect(SitemapGenerator::Utilities.as_array(nil)).to eq([])
+    it 'returns empty array on nil' do
+      expect(described_class.as_array(nil)).to eq([])
     end
 
-    it 'should make array of item otherwise' do
-      expect(SitemapGenerator::Utilities.as_array('')).to eq([''])
-      expect(SitemapGenerator::Utilities.as_array(1)).to eq([1])
-      expect(SitemapGenerator::Utilities.as_array('hello')).to eq(['hello'])
-      expect(SitemapGenerator::Utilities.as_array({})).to eq([{}])
+    it 'makes array of item otherwise' do
+      expect(described_class.as_array('')).to eq([''])
+      expect(described_class.as_array(1)).to eq([1])
+      expect(described_class.as_array('hello')).to eq(['hello'])
+      expect(described_class.as_array({})).to eq([{}])
     end
   end
 
   describe 'append_slash' do
-    it 'should yield the expect result' do
-      expect(SitemapGenerator::Utilities.append_slash('')).to eq('')
-      expect(SitemapGenerator::Utilities.append_slash(nil)).to eq('')
-      expect(SitemapGenerator::Utilities.append_slash(Pathname.new(''))).to eq('')
-      expect(SitemapGenerator::Utilities.append_slash('tmp')).to eq('tmp/')
-      expect(SitemapGenerator::Utilities.append_slash(Pathname.new('tmp'))).to eq('tmp/')
-      expect(SitemapGenerator::Utilities.append_slash('tmp/')).to eq('tmp/')
-      expect(SitemapGenerator::Utilities.append_slash(Pathname.new('tmp/'))).to eq('tmp/')
+    it 'yields the expect result' do
+      expect(described_class.append_slash('')).to eq('')
+      expect(described_class.append_slash(nil)).to eq('')
+      expect(described_class.append_slash(Pathname.new(''))).to eq('')
+      expect(described_class.append_slash('tmp')).to eq('tmp/')
+      expect(described_class.append_slash(Pathname.new('tmp'))).to eq('tmp/')
+      expect(described_class.append_slash('tmp/')).to eq('tmp/')
+      expect(described_class.append_slash(Pathname.new('tmp/'))).to eq('tmp/')
     end
   end
 
   describe 'ellipsis' do
-    it 'should not modify when less than or equal to max' do
-      (1..10).each do |i|
-        string = 'a'*i
-        expect(SitemapGenerator::Utilities.ellipsis(string, 10)).to eq(string)
+    context 'when string length is less than or equal to max' do
+      it 'returns the string unchanged' do
+        (1..10).each do |i|
+          string = 'a' * i
+          expect(described_class.ellipsis(string, 10)).to eq(string)
+        end
       end
     end
 
-    it 'should replace last 3 characters with ellipsis when greater than max' do
-      (1..5).each do |i|
-        string = 'aaaaa' + 'a'*i
-        expect(SitemapGenerator::Utilities.ellipsis(string, 5)).to eq('aa...')
+    context 'when string length is greater than max' do
+      it 'replaces the last 3 characters with ellipsis' do
+        (1..5).each do |i|
+          string = "aaaaa#{'a' * i}"
+          expect(described_class.ellipsis(string, 5)).to eq('aa...')
+        end
       end
     end
 
-    it 'should not freak out when string too small' do
-      expect(SitemapGenerator::Utilities.ellipsis('a', 1)).to eq('a')
-      expect(SitemapGenerator::Utilities.ellipsis('aa', 1)).to eq('...')
-      expect(SitemapGenerator::Utilities.ellipsis('aaa', 1)).to eq('...')
+    context 'when string is shorter than the ellipsis itself' do
+      it 'returns ellipsis' do
+        expect(described_class.ellipsis('a', 1)).to eq('a')
+        expect(described_class.ellipsis('aa', 1)).to eq('...')
+        expect(described_class.ellipsis('aaa', 1)).to eq('...')
+      end
     end
   end
 
@@ -105,6 +112,7 @@ RSpec.describe SitemapGenerator::Utilities do
     let(:tmp_dir) { Dir.mktmpdir }
 
     before do
+      SitemapGenerator::Sitemap.reset!
       SitemapGenerator::Sitemap.public_path = tmp_dir
     end
 
@@ -117,7 +125,7 @@ RSpec.describe SitemapGenerator::Utilities do
       it 'removes .xml.gz files from the configured directory' do
         FileUtils.touch(File.join(tmp_dir, 'sitemap.xml.gz'))
         FileUtils.touch(File.join(tmp_dir, 'sitemap1.xml.gz'))
-        SitemapGenerator::Utilities.clean_files
+        described_class.clean_files
         expect(Dir["#{tmp_dir}/sitemap*.xml.gz"]).to be_empty
       end
     end
@@ -126,7 +134,7 @@ RSpec.describe SitemapGenerator::Utilities do
       it 'removes .xml files from the configured directory' do
         FileUtils.touch(File.join(tmp_dir, 'sitemap.xml'))
         FileUtils.touch(File.join(tmp_dir, 'sitemap1.xml'))
-        SitemapGenerator::Utilities.clean_files
+        described_class.clean_files
         expect(Dir["#{tmp_dir}/sitemap*.xml"]).to be_empty
       end
     end
@@ -141,13 +149,13 @@ RSpec.describe SitemapGenerator::Utilities do
 
       it 'removes files from the configured subdirectory' do
         FileUtils.touch(File.join(sub_dir, 'sitemap.xml.gz'))
-        SitemapGenerator::Utilities.clean_files
+        described_class.clean_files
         expect(Dir["#{sub_dir}/sitemap*.xml.gz"]).to be_empty
       end
 
       it 'does not remove files outside the configured subdirectory' do
         FileUtils.touch(File.join(tmp_dir, 'sitemap.xml.gz'))
-        SitemapGenerator::Utilities.clean_files
+        described_class.clean_files
         expect(File.exist?(File.join(tmp_dir, 'sitemap.xml.gz'))).to be(true)
       end
     end

--- a/spec/sitemap_generator/utilities_spec.rb
+++ b/spec/sitemap_generator/utilities_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tmpdir'
 
 RSpec.describe SitemapGenerator::Utilities do
   describe 'assert_valid_keys' do

--- a/spec/sitemap_generator/utilities_spec.rb
+++ b/spec/sitemap_generator/utilities_spec.rb
@@ -100,4 +100,56 @@ RSpec.describe SitemapGenerator::Utilities do
       expect(SitemapGenerator::Utilities.ellipsis('aaa', 1)).to eq('...')
     end
   end
+
+  describe '.clean_files' do
+    let(:tmp_dir) { Dir.mktmpdir }
+
+    before do
+      SitemapGenerator::Sitemap.public_path = tmp_dir
+    end
+
+    after do
+      SitemapGenerator::Sitemap.reset!
+      FileUtils.rm_rf(tmp_dir)
+    end
+
+    context 'when sitemaps are compressed' do
+      it 'removes .xml.gz files from the configured directory' do
+        FileUtils.touch(File.join(tmp_dir, 'sitemap.xml.gz'))
+        FileUtils.touch(File.join(tmp_dir, 'sitemap1.xml.gz'))
+        SitemapGenerator::Utilities.clean_files
+        expect(Dir["#{tmp_dir}/sitemap*.xml.gz"]).to be_empty
+      end
+    end
+
+    context 'when sitemaps are uncompressed' do
+      it 'removes .xml files from the configured directory' do
+        FileUtils.touch(File.join(tmp_dir, 'sitemap.xml'))
+        FileUtils.touch(File.join(tmp_dir, 'sitemap1.xml'))
+        SitemapGenerator::Utilities.clean_files
+        expect(Dir["#{tmp_dir}/sitemap*.xml"]).to be_empty
+      end
+    end
+
+    context 'when a custom sitemaps_path is configured' do
+      let(:sub_dir) { File.join(tmp_dir, 'sitemaps', 'en') }
+
+      before do
+        FileUtils.mkdir_p(sub_dir)
+        SitemapGenerator::Sitemap.sitemaps_path = 'sitemaps/en'
+      end
+
+      it 'removes files from the configured subdirectory' do
+        FileUtils.touch(File.join(sub_dir, 'sitemap.xml.gz'))
+        SitemapGenerator::Utilities.clean_files
+        expect(Dir["#{sub_dir}/sitemap*.xml.gz"]).to be_empty
+      end
+
+      it 'does not remove files outside the configured subdirectory' do
+        FileUtils.touch(File.join(tmp_dir, 'sitemap.xml.gz'))
+        SitemapGenerator::Utilities.clean_files
+        expect(File.exist?(File.join(tmp_dir, 'sitemap.xml.gz'))).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fixes #474

## Problem

`rake sitemap:clean` calls `Utilities.clean_files`, which was hardcoded to:

```ruby
FileUtils.rm(Dir[SitemapGenerator.app.root + 'public/sitemap*.xml.gz'])
```

This missed two cases:
1. **Custom output path** — `sitemaps_path` and `public_path` configuration was ignored; files always looked up in `public/`
2. **Uncompressed sitemaps** — the glob only matched `*.xml.gz`, so sitemaps generated with `compress: false` or `compress: :all_but_first` (for the first file) were never deleted

## Fix

`clean_files` now reads the configured output directory from `SitemapGenerator::Sitemap.sitemap_location` and globs for both extensions:

```ruby
def clean_files
  location = SitemapGenerator::Sitemap.sitemap_location
  dir = location.directory
  base = SitemapGenerator::Sitemap.filename.to_s
  FileUtils.rm(Dir["#{dir}/#{base}*.xml.gz", "#{dir}/#{base}*.xml"])
end
```

Also fixes `--force-exclusion` missing from the RuboCop pre-commit hook, which caused `spec/**` files passed explicitly via xargs to bypass the `.rubocop.yml` exclusion list.

## Test plan

- [ ] `bundle exec rspec spec/sitemap_generator/utilities_spec.rb` — 16 examples, 0 failures
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)