### PR TITLE
fix: respect SitemapGenerator.verbose in rake tasks

### DIFF
--- a/lib/sitemap_generator/tasks.rb
+++ b/lib/sitemap_generator/tasks.rb
@@ -36,6 +36,6 @@ namespace :sitemap do
 
   desc "Generate sitemaps but don't ping search engines.  Alias for refresh:no_ping."
   task create: :require do
-    SitemapGenerator::Interpreter.run(config_file: ENV.fetch('CONFIG_FILE', nil), verbose: verbose)
+    SitemapGenerator::Interpreter.run(config_file: ENV.fetch('CONFIG_FILE', nil))
   end
 end

--- a/lib/sitemap_generator/tasks.rb
+++ b/lib/sitemap_generator/tasks.rb
@@ -18,6 +18,8 @@ namespace :sitemap do
 
   desc 'Install a default config/sitemap.rb file'
   task install: :require do
+    # Uses Rake's verbose flag intentionally — this is a file installation utility
+    # where Rake's -v/--verbose flag is the appropriate control mechanism.
     SitemapGenerator::Utilities.install_sitemap_rb(verbose)
   end
 

--- a/spec/sitemap_generator/tasks_spec.rb
+++ b/spec/sitemap_generator/tasks_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rake'
+require 'sitemap_generator/tasks'
+
+# rubocop:disable RSpec/SpecFilePathFormat
+RSpec.describe SitemapGenerator::Interpreter do
+  # rubocop:enable RSpec/SpecFilePathFormat
+
+  before do
+    Rake::Task.define_task(:environment) unless Rake::Task.task_defined?(:environment)
+  end
+
+  describe 'sitemap:create rake task' do
+    context 'when Rake verbose is true and SitemapGenerator.verbose is false' do
+      before do
+        SitemapGenerator::Sitemap.verbose = false
+        allow(Rake).to receive(:verbose).and_return(true)
+        allow(described_class).to receive(:run)
+      end
+
+      after do
+        SitemapGenerator::Sitemap.reset!
+      end
+
+      it 'does not pass verbose: to Interpreter.run' do
+        Rake::Task['sitemap:create'].execute
+        expect(described_class).to have_received(:run).with(hash_excluding(:verbose))
+      end
+    end
+  end
+end

--- a/spec/sitemap_generator/tasks_spec.rb
+++ b/spec/sitemap_generator/tasks_spec.rb
@@ -4,10 +4,9 @@ require 'spec_helper'
 require 'rake'
 require 'sitemap_generator/tasks'
 
-# rubocop:disable RSpec/SpecFilePathFormat
-RSpec.describe SitemapGenerator::Interpreter do
-  # rubocop:enable RSpec/SpecFilePathFormat
-
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Rake Tasks' do
+  # rubocop:enable RSpec/DescribeClass
   before do
     Rake::Task.define_task(:environment) unless Rake::Task.task_defined?(:environment)
   end
@@ -17,7 +16,7 @@ RSpec.describe SitemapGenerator::Interpreter do
       before do
         SitemapGenerator::Sitemap.verbose = false
         allow(Rake).to receive(:verbose).and_return(true)
-        allow(described_class).to receive(:run)
+        allow(SitemapGenerator::Interpreter).to receive(:run)
       end
 
       after do
@@ -26,7 +25,7 @@ RSpec.describe SitemapGenerator::Interpreter do
 
       it 'does not pass verbose: to Interpreter.run' do
         Rake::Task['sitemap:create'].execute
-        expect(described_class).to have_received(:run).with(hash_excluding(:verbose))
+        expect(SitemapGenerator::Interpreter).to have_received(:run).with(hash_excluding(:verbose))
       end
     end
   end


### PR DESCRIPTION
## Summary

- Removes the `verbose: verbose` kwarg passed to `SitemapGenerator::Interpreter.run` in the `sitemap:create` rake task
- `LinkSet#verbose` already reads from `SitemapGenerator.verbose` when `@verbose` is nil, so not passing it lets the gem's own verbose setting take effect
- Prevents Rake's verbose flag (which can return unexpected non-boolean values when tasks are invoked programmatically) from overriding a user's `SitemapGenerator.verbose = false` configuration

Closes #332

## Test plan

- [ ] Run `bundle exec rspec spec/sitemap_generator/tasks_spec.rb` — new spec asserts `Interpreter.run` is called without `verbose:` even when Rake's verbose is true
- [ ] Run `bundle exec rake spec` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)