### PR TITLE
fix: derive key, filename and content_type from location in ActiveStorageAdapter

### DIFF
--- a/lib/sitemap_generator.rb
+++ b/lib/sitemap_generator.rb
@@ -13,7 +13,7 @@ require 'sitemap_generator/sitemap_location'
 module SitemapGenerator
   autoload(:Interpreter,              'sitemap_generator/interpreter')
   autoload(:FileAdapter,              'sitemap_generator/adapters/file_adapter')
-  autoload(:ActiveStorageAdapter,     'sitemap_generator/adapters/active_storage_adapter') if defined?(::ActiveStorage)
+  autoload(:ActiveStorageAdapter,     'sitemap_generator/adapters/active_storage_adapter')
   autoload(:S3Adapter,                'sitemap_generator/adapters/s3_adapter')
   autoload(:AwsSdkAdapter,            'sitemap_generator/adapters/aws_sdk_adapter')
   autoload(:WaveAdapter,              'sitemap_generator/adapters/wave_adapter')

--- a/lib/sitemap_generator/adapters/active_storage_adapter.rb
+++ b/lib/sitemap_generator/adapters/active_storage_adapter.rb
@@ -1,18 +1,14 @@
 # frozen_string_literal: true
 
+raise LoadError, "ActiveStorage is not available. Add 'activestorage' to your Gemfile." unless defined?(ActiveStorage)
+
 module SitemapGenerator
   # Class for uploading sitemaps to ActiveStorage.
   class ActiveStorageAdapter
-    attr_reader :key, :filename
-
-    def initialize(key: :sitemap, filename: 'sitemap.xml.gz')
-      @key = key
-      @filename = filename
-    end
-
     def write(location, raw_data) # rubocop:disable Metrics/MethodLength
       SitemapGenerator::FileAdapter.new.write(location, raw_data)
 
+      key = location.path_in_public
       ActiveStorage::Blob.transaction do
         ActiveStorage::Blob.where(key: key).destroy_all
 
@@ -20,8 +16,8 @@ module SitemapGenerator
           ActiveStorage::Blob.create_and_upload!(
             key: key,
             io: io,
-            filename: filename,
-            content_type: 'application/gzip',
+            filename: location.filename.to_s,
+            content_type: location.content_type,
             identify: false
           )
         end

--- a/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
@@ -1,20 +1,30 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
+module ActiveStorage; end unless defined?(ActiveStorage) # rubocop:disable Lint/EmptyModule
 require 'sitemap_generator/adapters/active_storage_adapter'
 
 RSpec.describe 'SitemapGenerator::ActiveStorageAdapter' do
-  let(:location) { SitemapGenerator::SitemapLocation.new }
-  let(:adapter)  { SitemapGenerator::ActiveStorageAdapter.new }
-  let(:fake_active_storage_blob) {
+  let(:location) do
+    SitemapGenerator::SitemapLocation.new(
+      namer: SitemapGenerator::SimpleNamer.new(:sitemap, start: 2, zero: 1),
+      public_path: 'tmp/',
+      sitemaps_path: 'sitemaps/',
+      host: 'http://example.com/'
+    )
+  end
+  let(:adapter) { SitemapGenerator::ActiveStorageAdapter.new }
+  let(:fake_active_storage_blob) do
     Class.new do
       def self.transaction
         yield
       end
 
-      def self.where(*args)
+      def self.where(*_args)
         FakeScope.new
       end
 
-      def self.create_and_upload!(**kwargs)
+      def self.create_and_upload!(**_kwargs)
         'ActiveStorage::Blob'
       end
 
@@ -24,16 +34,50 @@ RSpec.describe 'SitemapGenerator::ActiveStorageAdapter' do
         end
       end
     end
-  }
+  end
 
   before do
     stub_const('ActiveStorage::Blob', fake_active_storage_blob)
+    allow(SitemapGenerator::FileAdapter).to receive_message_chain(:new, :write)
+    allow(File).to receive(:open).and_yield(StringIO.new('data'))
   end
 
   describe 'write' do
-    it 'should create an ActiveStorage::Blob record' do
-      expect(location).to receive(:filename).and_return('sitemap.xml.gz').at_least(2).times
-      expect(adapter.write(location, 'data')).to eq 'ActiveStorage::Blob'
+    it 'uses location.path_in_public as the blob key' do
+      expect(fake_active_storage_blob).to receive(:where).with(key: location.path_in_public).and_call_original
+      adapter.write(location, 'data')
+    end
+
+    it 'uses location.filename as the blob filename' do
+      captured = nil
+      allow(fake_active_storage_blob).to receive(:create_and_upload!) { |**kwargs| captured = kwargs; 'blob' }
+      adapter.write(location, 'data')
+      expect(captured[:filename]).to eq(location.filename.to_s)
+    end
+
+    it 'uses location.content_type as the blob content_type' do
+      captured = nil
+      allow(fake_active_storage_blob).to receive(:create_and_upload!) { |**kwargs| captured = kwargs; 'blob' }
+      adapter.write(location, 'data')
+      expect(captured[:content_type]).to eq(location.content_type)
+    end
+
+    context 'when sitemaps are uncompressed' do
+      let(:location) do
+        SitemapGenerator::SitemapLocation.new(
+          namer: SitemapGenerator::SimpleNamer.new(:sitemap, start: 2, zero: 1),
+          public_path: 'tmp/',
+          host: 'http://example.com/',
+          compress: false
+        )
+      end
+
+      it 'uses application/xml content_type' do
+        captured = nil
+        allow(fake_active_storage_blob).to receive(:create_and_upload!) { |**kwargs| captured = kwargs; 'blob' }
+        adapter.write(location, 'data')
+        expect(captured[:content_type]).to eq('application/xml')
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #479

## Summary
- Key is now derived from `location.path_in_public` (unique per file — handles multiple sitemaps and custom filenames correctly)
- Filename is now derived from `location.filename.to_s` (respects `filename:` configuration)
- Content-type is now derived from `location.content_type` (returns `application/x-gzip` or `application/xml` depending on `compress:` setting)
- Autoload for `ActiveStorageAdapter` is now registered unconditionally; the guard (`raise LoadError unless defined?(ActiveStorage)`) lives inside the adapter file — consistent with the `AwsSdkAdapter` pattern so the adapter loads correctly regardless of gem load order

## Test plan
- [x] New specs verify key, filename, and content_type are all derived from `location`
- [x] Uncompressed sitemap produces `application/xml` content-type
- [x] Full test suite (422 examples) passes