### PR TITLE
chore(specs): enable RuboCop to catch broken and silently-passing tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,11 +12,113 @@ AllCops:
     - bin/*
     - gemfiles/*
     - pkg/**/*
-    - spec/**/*
     - vendor/**/*
     - integration/bin/*
-    - integration/spec/**/*
 
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
+
+# --- Test-suite relaxations (spec/**/*, integration/spec/**/*) ---
+# RuboCop was enabled on the test suite in 2026-07 (previously fully excluded).
+# The cops below are disabled/relaxed because fixing them means restructuring
+# a large fraction of the existing suite -- tracked as deliberate follow-up
+# work, not permanent exceptions. Revisit and re-enable individually as the
+# underlying tests get migrated.
+
+RSpec/MultipleExpectations:
+  Enabled: false # TODO: follow-up -- split multi-assert examples (172 instances, 31 files)
+
+RSpec/MessageSpies:
+  Enabled: false # TODO: follow-up -- migrate expect().to receive to allow/have_received (85 instances, 13 files)
+
+RSpec/StubbedMock:
+  Enabled: false # TODO: follow-up -- same migration as RSpec/MessageSpies (36 instances, 9 files)
+
+RSpec/InstanceVariable:
+  Enabled: false # TODO: follow-up -- convert @ivar usage to let (57 instances, 5 files)
+
+RSpec/SpecFilePathFormat:
+  Enabled: false # TODO: follow-up -- some are permanent (core_ext/adapters subdirectory layout), some
+                 # could be renamed (sitemap_namer_spec.rb, utilities/*); triage file-by-file (10 instances)
+
+RSpec/VerifiedDoubles:
+  Enabled: false # TODO: follow-up -- migrate plain doubles to instance_double/class_double (13 instances, 4 files)
+
+RSpec/ExpectInHook:
+  Enabled: false # TODO: follow-up -- move expectations out of before/after hooks into the example (9 instances, 5 files)
+
+RSpec/BeforeAfterAll:
+  Enabled: false # TODO: follow-up -- review before(:all)/after(:all) for state-leak risk (8 instances, 3 files)
+
+RSpec/AnyInstance:
+  Enabled: false # TODO: follow-up -- expect_any_instance_of in adapter specs; consider injectable SDK clients (3 instances)
+
+RSpec/SubjectStub:
+  Enabled: false # TODO: follow-up -- stubbing methods on the subject under test, sitemap_location_spec.rb (3 instances)
+
+RSpec/MultipleDescribes:
+  Enabled: false # TODO: follow-up -- nest the two top-level describes in sitemap_location_spec.rb (1 instance)
+
+RSpec/ExampleLength:
+  Enabled: false # TODO: follow-up -- several examples run 15-40 lines (XML fixture building,
+                 # multi-step sitemap generation); split up rather than pick an arbitrary Max
+
+RSpec/NestedGroups:
+  Max: 5 # default is 3; a few adapter/interpreter specs nest one or two levels deeper
+
+RSpec/NoExpectationExample:
+  AllowedPatterns:
+    - "^expect_"
+    - "^assert_"
+    - "should" # this suite's custom expectation helpers are named e.g. file_should_exist
+
+Lint/EmptyBlock:
+  Exclude:
+    - spec/**/*
+    - integration/spec/**/*
+  # Permanent, not follow-up debt: every instance is `ls.create { |sitemap| }`, an
+  # intentionally empty block required because LinkSet#create only finalizes if
+  # block_given?. Scoped here (not Enabled: false) so lib/ keeps full enforcement.
+
+Style/Documentation:
+  Exclude:
+    - spec/**/*
+    - integration/spec/**/*
+  # Permanent, not follow-up debt: doc comments on test scaffolding/dummy-app fixtures
+  # add no value. Scoped here (not Enabled: false) so lib/ keeps full enforcement.
+
+Metrics/AbcSize:
+  Exclude:
+    - spec/sitemap_generator/sitemaps/video_sitemap_spec.rb
+  # TODO: follow-up -- validate_video_element test helper could be split up.
+
+Metrics/MethodLength:
+  Exclude:
+    - spec/sitemap_generator/sitemaps/video_sitemap_spec.rb
+  # TODO: follow-up -- same helper as Metrics/AbcSize above.
+
+Lint/ConstantDefinitionInBlock:
+  Exclude:
+    - spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+  # TODO: follow-up -- inline stub-class constant used for the ActiveStorage adapter double.
+
+RSpec/LeakyConstantDeclaration:
+  Exclude:
+    - spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+  # TODO: follow-up -- same stub double as Lint/ConstantDefinitionInBlock above.
+
+Naming/PredicateMethod:
+  Exclude:
+    - spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+  # TODO: follow-up -- same stub double as Lint/ConstantDefinitionInBlock above.
+
+RSpec/RemoveConst:
+  Exclude:
+    - integration/spec/sitemap_generator/tasks_spec.rb
+  # TODO: follow-up -- replace remove_const with stub_const in this rake-task spec.
+
+Naming/ConstantName:
+  Exclude:
+    - integration/spec/sitemap_generator/tasks_spec.rb
+  # TODO: follow-up -- same rake-task spec constant as RSpec/RemoveConst above.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,7 @@ RSpec/MultipleExpectations:
   Enabled: false # TODO: follow-up -- split multi-assert examples (172 instances, 31 files)
 
 RSpec/MessageSpies:
-  Enabled: false # TODO: follow-up -- migrate expect().to receive to allow/have_received (85 instances, 13 files)
+  EnforcedStyle: receive # matches this suite's established expect().to receive convention
 
 RSpec/StubbedMock:
   Enabled: false # TODO: follow-up -- same migration as RSpec/MessageSpies (36 instances, 9 files)
@@ -71,15 +71,9 @@ RSpec/NoExpectationExample:
   AllowedPatterns:
     - "^expect_"
     - "^assert_"
-    - "should" # this suite's custom expectation helpers are named e.g. file_should_exist
-
-Lint/EmptyBlock:
-  Exclude:
-    - spec/**/*
-    - integration/spec/**/*
-  # Permanent, not follow-up debt: every instance is `ls.create { |sitemap| }`, an
-  # intentionally empty block required because LinkSet#create only finalizes if
-  # block_given?. Scoped here (not Enabled: false) so lib/ keeps full enforcement.
+    - "should" # this suite's custom expectation helpers are named e.g. file_should_exist.
+               # TODO: follow-up -- move away from the should_* helper naming/style entirely
+               # rather than special-casing it here; not addressing now (out of scope).
 
 Style/Documentation:
   Exclude:

--- a/integration/spec/files/sitemap.create.rb
+++ b/integration/spec/files/sitemap.create.rb
@@ -1,12 +1,14 @@
-SitemapGenerator::Sitemap.default_host = "http://www.example.com"
+# frozen_string_literal: true
+
+SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
 
 SitemapGenerator::Sitemap.create do
-  add contents_path, :priority => 0.7, :changefreq => 'daily'
+  add contents_path, priority: 0.7, changefreq: 'daily'
 
   # add all individual articles
   Content.all.each do |c|
-    add content_path(c), :lastmod => c.updated_at
+    add content_path(c), lastmod: c.updated_at
   end
 
-  add "/merchant_path", :host => "https://www.example.com"
+  add '/merchant_path', host: 'https://www.example.com'
 end

--- a/integration/spec/files/sitemap.groups.rb
+++ b/integration/spec/files/sitemap.groups.rb
@@ -1,28 +1,29 @@
-SitemapGenerator::Sitemap.default_host = "http://www.example.com"
+# frozen_string_literal: true
+
+SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
 
 SitemapGenerator::Sitemap.create(
-    :include_root => true, :include_index => true,
-    :filename => :new_sitemaps, :sitemaps_path => 'fr/') do
-
-  add('/one', :priority => 0.7, :changefreq => 'daily')
+  include_root: true, include_index: true,
+  filename: :new_sitemaps, sitemaps_path: 'fr/'
+) do
+  add('/one', priority: 0.7, changefreq: 'daily')
 
   # Test a new location and filename and sitemaps host
-  group(:sitemaps_path => 'en/', :filename => :xxx,
-      :sitemaps_host => "http://newhost.com") do
-
+  group(sitemaps_path: 'en/', filename: :xxx,
+        sitemaps_host: 'http://newhost.com') do
     add '/two'
     add '/three'
   end
 
   # Test a simple namer.
-  group(:namer => SitemapGenerator::SimpleNamer.new(:abc, :start => 4, :zero => 3)) do
+  group(namer: SitemapGenerator::SimpleNamer.new(:abc, start: 4, zero: 3)) do
     add '/four'
     add '/five'
     add '/six'
   end
 
   # Test a simple namer
-  group(:namer => SitemapGenerator::SimpleNamer.new(:def)) do
+  group(namer: SitemapGenerator::SimpleNamer.new(:def)) do
     add '/four'
     add '/five'
     add '/six'
@@ -33,7 +34,7 @@ SitemapGenerator::Sitemap.create(
   # This should be in a file of its own.
   # Not technically valid to have a link with a different host, but people like
   # to do strange things sometimes.
-  group(:sitemaps_host => "http://exceptional.com") do
+  group(sitemaps_host: 'http://exceptional.com') do
     add '/eight'
     add '/nine'
   end
@@ -42,5 +43,5 @@ SitemapGenerator::Sitemap.create(
 
   # Not technically valid to have a link with a different host, but people like
   # to do strange things sometimes
-  add "/merchant_path", :host => "https://www.merchanthost.com"
+  add '/merchant_path', host: 'https://www.merchanthost.com'
 end

--- a/integration/spec/internal/app/controllers/application_controller.rb
+++ b/integration/spec/internal/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery
 end

--- a/integration/spec/internal/app/controllers/contents_controller.rb
+++ b/integration/spec/internal/app/controllers/contents_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContentsController < ApplicationController
   def index
     render plain: 'ok'

--- a/integration/spec/internal/app/models/content.rb
+++ b/integration/spec/internal/app/models/content.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Content < ActiveRecord::Base
   validates_presence_of :title
 end

--- a/integration/spec/internal/config/routes.rb
+++ b/integration/spec/internal/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   resources :contents
 end

--- a/integration/spec/internal/config/sitemap.rb
+++ b/integration/spec/internal/config/sitemap.rb
@@ -1,12 +1,14 @@
-SitemapGenerator::Sitemap.default_host = "http://www.example.com"
+# frozen_string_literal: true
+
+SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
 
 SitemapGenerator::Sitemap.create do
-  add contents_path, :priority => 0.7, :changefreq => 'daily'
+  add contents_path, priority: 0.7, changefreq: 'daily'
 
   # add all individual articles
   Content.all.each do |c|
-    add content_path(c), :lastmod => c.updated_at
+    add content_path(c), lastmod: c.updated_at
   end
 
-  add "/merchant_path", :host => "https://www.example.com"
+  add '/merchant_path', host: 'https://www.example.com'
 end

--- a/integration/spec/internal/db/schema.rb
+++ b/integration/spec/internal/db/schema.rb
@@ -1,7 +1,9 @@
-ActiveRecord::Schema.define(:version => 1) do
-  create_table "contents", force: true do |t|
-    t.string   "title"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+# frozen_string_literal: true
+
+ActiveRecord::Schema.define(version: 1) do
+  create_table 'contents', force: true do |t|
+    t.string   'title'
+    t.datetime 'created_at'
+    t.datetime 'updated_at'
   end
 end

--- a/integration/spec/internal/db/seed.rb
+++ b/integration/spec/internal/db/seed.rb
@@ -1,3 +1,7 @@
-(1..10).each do |i|
-  Content.create!(:title => "content #{i}")
-end if Content.count == 0
+# frozen_string_literal: true
+
+if Content.none?
+  (1..10).each do |i|
+    Content.create!(title: "content #{i}")
+  end
+end

--- a/integration/spec/sitemap_generator/alternate_sitemap_spec.rb
+++ b/integration/spec/sitemap_generator/alternate_sitemap_spec.rb
@@ -1,16 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-RSpec.describe "SitemapGenerator" do
-  it "should not include media element unless provided" do
+RSpec.describe 'SitemapGenerator' do
+  it 'does not include media element unless provided' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternates => [
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html'
-        }
-      ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 lang: 'de',
+                                                                 href: 'http://www.example.de/link_with_alternate.html'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -24,17 +25,16 @@ RSpec.describe "SitemapGenerator" do
     expect(alternate.attribute('media')).to be_nil
   end
 
-  it "should add alternate links to sitemap" do
+  it 'adds alternate links to sitemap' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternates => [
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html',
-          :media => 'only screen and (max-width: 640px)'
-        }
-      ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 lang: 'de',
+                                                                 href: 'http://www.example.de/link_with_alternate.html',
+                                                                 media: 'only screen and (max-width: 640px)'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -49,18 +49,17 @@ RSpec.describe "SitemapGenerator" do
     expect(alternate.attribute('media').value).to eq('only screen and (max-width: 640px)')
   end
 
-  it "should add alternate links to sitemap with rel nofollow" do
+  it 'adds alternate links to sitemap with rel nofollow' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternates => [
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html',
-          :nofollow => true,
-          :media => 'only screen and (max-width: 640px)'
-        }
-      ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 lang: 'de',
+                                                                 href: 'http://www.example.de/link_with_alternate.html',
+                                                                 nofollow: true,
+                                                                 media: 'only screen and (max-width: 640px)'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -75,16 +74,14 @@ RSpec.describe "SitemapGenerator" do
     expect(alternate.attribute('media').value).to eq('only screen and (max-width: 640px)')
   end
 
-  it "should support adding a single alternate link" do
+  it 'supports adding a single alternate link' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternate =>
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html',
-          :nofollow => true
-        }
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternate: {
+                                                               lang: 'de',
+                                                               href: 'http://www.example.de/link_with_alternate.html',
+                                                               nofollow: true
+                                                             }).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -98,4 +95,3 @@ RSpec.describe "SitemapGenerator" do
     expect(alternate.attribute('href').value).to eq('http://www.example.de/link_with_alternate.html')
   end
 end
-

--- a/integration/spec/sitemap_generator/tasks_spec.rb
+++ b/integration/spec/sitemap_generator/tasks_spec.rb
@@ -231,7 +231,6 @@ RSpec.describe 'SitemapGenerator' do
     end
   end
 
-
   describe 'external dependencies' do
     describe 'rails' do
       before do

--- a/integration/spec/spec_helper.rb
+++ b/integration/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Fix uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger
 require 'logger'
 
@@ -45,7 +47,7 @@ RSpec.configure do |config|
 end
 
 module Helpers
-  extend self
+  module_function
 
   # Invoke and then re-enable the task so it can be called multiple times.
   # KJV: Tasks are only being run once despite being re-enabled.
@@ -57,8 +59,6 @@ module Helpers
     Rake::Task[task.to_s].reenable
   end
 end
-
-puts "Running RSpec with Rails version: #{Rails.version}"
 
 # Load our own gem
 require 'sitemap_generator/tasks' # Combusition fails to load these tasks

--- a/integration/spec/spec_helper.rb
+++ b/integration/spec/spec_helper.rb
@@ -60,6 +60,10 @@ module Helpers
   end
 end
 
+# rubocop:disable RSpec/Output -- useful in CI logs across the Appraisal Rails version matrix
+puts "Running RSpec with Rails version: #{Rails.version}"
+# rubocop:enable RSpec/Output
+
 # Load our own gem
 require 'sitemap_generator/tasks' # Combusition fails to load these tasks
 SitemapGenerator.verbose = false

--- a/integration/spec/support/sitemap_macros.rb
+++ b/integration/spec/support/sitemap_macros.rb
@@ -19,11 +19,11 @@ module SitemapMacros
 
   def copy_sitemap_file_to_rails_app(extension)
     FileUtils.cp(File.join(this_root, "spec/files/sitemap.#{extension}.rb"),
-                 "#{SitemapGenerator.app.root}/config/sitemap.rb")
+                 SitemapGenerator.app.root.join('config/sitemap.rb'))
   end
 
   def delete_sitemap_file_from_rails_app
-    FileUtils.remove("#{SitemapGenerator.app.root}/config/sitemap.rb")
+    FileUtils.remove(SitemapGenerator.app.root.join('config/sitemap.rb'))
   rescue StandardError
     nil
   end

--- a/integration/spec/support/sitemap_macros.rb
+++ b/integration/spec/support/sitemap_macros.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SitemapMacros
   def with_max_links(num)
     original = SitemapGenerator::Sitemap.max_sitemap_links
@@ -16,12 +18,13 @@ module SitemapMacros
   end
 
   def copy_sitemap_file_to_rails_app(extension)
-    FileUtils.cp(File.join(this_root, "spec/files/sitemap.#{extension}.rb"), SitemapGenerator.app.root + 'config/sitemap.rb')
+    FileUtils.cp(File.join(this_root, "spec/files/sitemap.#{extension}.rb"),
+                 "#{SitemapGenerator.app.root}/config/sitemap.rb")
   end
 
   def delete_sitemap_file_from_rails_app
-    FileUtils.remove(SitemapGenerator.app.root + 'config/sitemap.rb')
-  rescue
+    FileUtils.remove("#{SitemapGenerator.app.root}/config/sitemap.rb")
+  rescue StandardError
     nil
   end
 

--- a/spec/files/sitemap.create.rb
+++ b/spec/files/sitemap.create.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
 
 SitemapGenerator::Sitemap.create do
-  add '/contents', :priority => 0.7, :changefreq => 'daily'
+  add '/contents', priority: 0.7, changefreq: 'daily'
 
   # add all individual articles
   (1..10).each do |i|
-    add '/content/#{i}'
+    add "/content/#{i}"
   end
 
-  add '/merchant_path', :host => 'https://www.example.com'
+  add '/merchant_path', host: 'https://www.example.com'
 end

--- a/spec/files/sitemap.groups.rb
+++ b/spec/files/sitemap.groups.rb
@@ -1,28 +1,29 @@
+# frozen_string_literal: true
+
 SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
 
 SitemapGenerator::Sitemap.create(
-    :include_root => true, :include_index => true,
-    :filename => :new_sitemaps, :sitemaps_path => 'fr/') do
-
-  add('/one', :priority => 0.7, :changefreq => 'daily')
+  include_root: true, include_index: true,
+  filename: :new_sitemaps, sitemaps_path: 'fr/'
+) do
+  add('/one', priority: 0.7, changefreq: 'daily')
 
   # Test a new location and filename and sitemaps host
-  group(:sitemaps_path => 'en/', :filename => :xxx,
-      :sitemaps_host => 'http://newhost.com') do
-
+  group(sitemaps_path: 'en/', filename: :xxx,
+        sitemaps_host: 'http://newhost.com') do
     add '/two'
     add '/three'
   end
 
   # Test a simple namer.
-  group(:namer => SitemapGenerator::SimpleNamer.new(:abc, :start => 4, :zero => 3)) do
+  group(namer: SitemapGenerator::SimpleNamer.new(:abc, start: 4, zero: 3)) do
     add '/four'
     add '/five'
     add '/six'
   end
 
   # Test a simple namer
-  group(:namer => SitemapGenerator::SimpleNamer.new(:def)) do
+  group(namer: SitemapGenerator::SimpleNamer.new(:def)) do
     add '/four'
     add '/five'
     add '/six'
@@ -33,7 +34,7 @@ SitemapGenerator::Sitemap.create(
   # This should be in a file of its own.
   # Not technically valid to have a link with a different host, but people like
   # to do strange things sometimes.
-  group(:sitemaps_host => 'http://exceptional.com') do
+  group(sitemaps_host: 'http://exceptional.com') do
     add '/eight'
     add '/nine'
   end
@@ -42,5 +43,5 @@ SitemapGenerator::Sitemap.create(
 
   # Not technically valid to have a link with a different host, but people like
   # to do strange things sometimes
-  add '/merchant_path', :host => 'https://www.merchanthost.com'
+  add '/merchant_path', host: 'https://www.merchanthost.com'
 end

--- a/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/active_storage_adapter_spec.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sitemap_generator/adapters/active_storage_adapter'
 
 RSpec.describe 'SitemapGenerator::ActiveStorageAdapter' do
   let(:location) { SitemapGenerator::SitemapLocation.new }
   let(:adapter)  { SitemapGenerator::ActiveStorageAdapter.new }
-  let(:fake_active_storage_blob) {
+  let(:fake_active_storage_blob) do
     Class.new do
       def self.transaction
         yield
       end
 
-      def self.where(*args)
+      def self.where(*_args)
         FakeScope.new
       end
 
-      def self.create_and_upload!(**kwargs)
+      def self.create_and_upload!(**_kwargs)
         'ActiveStorage::Blob'
       end
 
@@ -24,15 +26,15 @@ RSpec.describe 'SitemapGenerator::ActiveStorageAdapter' do
         end
       end
     end
-  }
+  end
 
   before do
     stub_const('ActiveStorage::Blob', fake_active_storage_blob)
   end
 
   describe 'write' do
-    it 'should create an ActiveStorage::Blob record' do
-      expect(location).to receive(:filename).and_return('sitemap.xml.gz').at_least(2).times
+    it 'creates an ActiveStorage::Blob record' do
+      expect(location).to receive(:filename).and_return('sitemap.xml.gz').at_least(:twice)
       expect(adapter.write(location, 'data')).to eq 'ActiveStorage::Blob'
     end
   end

--- a/spec/sitemap_generator/adapters/aws_sdk_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/aws_sdk_adapter_spec.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'aws-sdk-core'
 require 'aws-sdk-s3'
 
 RSpec.describe SitemapGenerator::AwsSdkAdapter do
-  subject(:adapter)  { described_class.new('bucket', **options) }
+  subject(:adapter) { described_class.new('bucket', **options) }
 
   let(:location) { SitemapGenerator::SitemapLocation.new(compress: compress) }
   let(:options) { {} }
   let(:compress) { nil }
 
-  shared_examples 'it writes the raw data to a file and then uploads that file to S3' do |acl, cache_control, content_type, path = 'path'|
+  shared_examples 'writes and uploads the file to S3' do |acl, cache_control, content_type, path = 'path'|
     before do
       expect_any_instance_of(SitemapGenerator::FileAdapter).to receive(:write).with(location, 'raw_data')
       expect(location).to receive(:path_in_public).and_return('path_in_public')
@@ -23,12 +25,12 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
         expect(Aws::S3::Client).to receive(:new).and_return(s3_client)
         expect(Aws::S3::TransferManager).to receive(:new).with(client: s3_client).and_return(transfer_manager)
         expect(transfer_manager).to receive(:upload_file).with(path, hash_including(
-          bucket: 'bucket',
-          key: 'path_in_public',
-          acl: acl,
-          cache_control: cache_control,
-          content_type: content_type
-        )).and_return(nil)
+                                                                       bucket: 'bucket',
+                                                                       key: 'path_in_public',
+                                                                       acl: acl,
+                                                                       cache_control: cache_control,
+                                                                       content_type: content_type
+                                                                     )).and_return(nil)
         adapter.write(location, 'raw_data')
       end
     else
@@ -40,16 +42,16 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
         expect(s3_resource).to receive(:bucket).with('bucket').and_return(s3_bucket)
         expect(s3_bucket).to receive(:object).with('path_in_public').and_return(s3_object)
         expect(s3_object).to receive(:upload_file).with(path, hash_including(
-          acl: acl,
-          cache_control: cache_control,
-          content_type: content_type
-        )).and_return(nil)
+                                                                acl: acl,
+                                                                cache_control: cache_control,
+                                                                content_type: content_type
+                                                              )).and_return(nil)
         adapter.write(location, 'raw_data')
       end
     end
   end
 
-  shared_examples "deprecated option" do |deprecated_key, new_key|
+  shared_examples 'deprecated option' do |deprecated_key, new_key|
     context 'when a deprecated option set' do
       context 'when it is not nil' do
         let(:options) do
@@ -57,7 +59,7 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
         end
 
         it 'sets the option' do
-          expect(adapterOptions[new_key]).to eq('value')
+          expect(adapter_options[new_key]).to eq('value')
         end
 
         context 'when the new option key is set' do
@@ -67,7 +69,7 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
             end
 
             it 'does not override it' do
-              expect(adapterOptions[new_key]).to eq('new_endpoint')
+              expect(adapter_options[new_key]).to eq('new_endpoint')
             end
           end
 
@@ -77,7 +79,7 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
             end
 
             it 'overrides it' do
-              expect(adapterOptions[new_key]).to eq('value')
+              expect(adapter_options[new_key]).to eq('value')
             end
           end
         end
@@ -89,7 +91,7 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
         end
 
         it 'does not set the option' do
-          expect(adapterOptions).not_to have_key(new_key)
+          expect(adapter_options).not_to have_key(new_key)
         end
       end
     end
@@ -100,7 +102,7 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
       hide_const('Aws::S3::Resource')
       expect do
         load File.expand_path('./lib/sitemap_generator/adapters/aws_sdk_adapter.rb')
-      end.to raise_error(LoadError, /Error: `Aws::S3::Resource` and\/or `Aws::Credentials` are not defined/)
+      end.to raise_error(LoadError, %r{Error: `Aws::S3::Resource` and/or `Aws::Credentials` are not defined})
     end
   end
 
@@ -109,25 +111,28 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
       hide_const('Aws::Credentials')
       expect do
         load File.expand_path('./lib/sitemap_generator/adapters/aws_sdk_adapter.rb')
-      end.to raise_error(LoadError, /Error: `Aws::S3::Resource` and\/or `Aws::Credentials` are not defined/)
+      end.to raise_error(LoadError, %r{Error: `Aws::S3::Resource` and/or `Aws::Credentials` are not defined})
     end
   end
 
   describe '#write' do
     context 'with no compress option' do
-      it_behaves_like 'it writes the raw data to a file and then uploads that file to S3', 'public-read', 'private, max-age=0, no-cache', 'application/x-gzip', 'sitemap.xml.gz'
+      it_behaves_like 'writes and uploads the file to S3', 'public-read',
+                      'private, max-age=0, no-cache', 'application/x-gzip', 'sitemap.xml.gz'
     end
 
     context 'with compress true' do
       let(:compress) { true }
 
-      it_behaves_like 'it writes the raw data to a file and then uploads that file to S3', 'public-read', 'private, max-age=0, no-cache', 'application/x-gzip', 'sitemap.xml.gz'
+      it_behaves_like 'writes and uploads the file to S3', 'public-read',
+                      'private, max-age=0, no-cache', 'application/x-gzip', 'sitemap.xml.gz'
     end
 
     context 'when compress is :all_but_first and path does not end in .gz' do
       let(:compress) { :all_but_first }
 
-      it_behaves_like 'it writes the raw data to a file and then uploads that file to S3', 'public-read', 'private, max-age=0, no-cache', 'application/xml', 'sitemap.xml'
+      it_behaves_like 'writes and uploads the file to S3', 'public-read',
+                      'private, max-age=0, no-cache', 'application/xml', 'sitemap.xml'
     end
 
     context 'with acl and cache control configured' do
@@ -135,16 +140,17 @@ RSpec.describe SitemapGenerator::AwsSdkAdapter do
         { acl: 'private', cache_control: 'public, max-age=3600' }
       end
 
-      it_behaves_like 'it writes the raw data to a file and then uploads that file to S3', 'private', 'public, max-age=3600', 'application/x-gzip', 'sitemap.xml.gz'
+      it_behaves_like 'writes and uploads the file to S3', 'private',
+                      'public, max-age=3600', 'application/x-gzip', 'sitemap.xml.gz'
     end
   end
 
   describe '#initialize' do
-    subject(:adapterOptions) { adapter.instance_variable_get(:@options) }
+    subject(:adapter_options) { adapter.instance_variable_get(:@options) }
 
-    it_behaves_like "deprecated option", :aws_endpoint, :endpoint
-    it_behaves_like "deprecated option", :aws_access_key_id, :access_key_id
-    it_behaves_like "deprecated option", :aws_secret_access_key, :secret_access_key
-    it_behaves_like "deprecated option", :aws_region, :region
+    it_behaves_like 'deprecated option', :aws_endpoint, :endpoint
+    it_behaves_like 'deprecated option', :aws_access_key_id, :access_key_id
+    it_behaves_like 'deprecated option', :aws_secret_access_key, :secret_access_key
+    it_behaves_like 'deprecated option', :aws_region, :region
   end
 end

--- a/spec/sitemap_generator/adapters/fog_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/fog_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'fog-aws'
 

--- a/spec/sitemap_generator/adapters/google_storage_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/google_storage_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'google/cloud/storage'
 
@@ -10,7 +12,8 @@ RSpec.describe SitemapGenerator::GoogleStorageAdapter do
     it 'writes the raw data to a file and then uploads that file to Google Storage' do
       storage = double(:storage)
       bucket_resource = double(:bucket_resource)
-      expect(Google::Cloud::Storage).to receive(:new).with(credentials: 'abc', project_id: 'project_id').and_return(storage)
+      expect(Google::Cloud::Storage).to receive(:new).with(credentials: 'abc',
+                                                           project_id: 'project_id').and_return(storage)
       expect(storage).to receive(:bucket).with('bucket').and_return(bucket_resource)
       expect(location).to receive(:path_in_public).and_return('path_in_public')
       expect(location).to receive(:path).and_return('path')

--- a/spec/sitemap_generator/adapters/s3_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/s3_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'fog-aws'
 
@@ -6,23 +8,20 @@ RSpec.describe SitemapGenerator::S3Adapter do
 
   let(:location) do
     SitemapGenerator::SitemapLocation.new(
-      :namer => SitemapGenerator::SimpleNamer.new(:sitemap),
-      :public_path => 'tmp/',
-      :sitemaps_path => 'test/',
-      :host => 'http://example.com/')
+      namer: SitemapGenerator::SimpleNamer.new(:sitemap),
+      public_path: 'tmp/',
+      sitemaps_path: 'test/',
+      host: 'http://example.com/'
+    )
   end
   let(:directory) do
     double('directory',
-      :files => double('files', :create => nil)
-    )
+           files: double('files', create: nil))
   end
   let(:directories) do
     double('directories',
-      :directories =>
-        double('directory class',
-          :new => directory
-        )
-    )
+           directories: double('directory class',
+                               new: directory))
   end
   let(:options) do
     {
@@ -34,7 +33,7 @@ RSpec.describe SitemapGenerator::S3Adapter do
       fog_region: 'fog_region',
       fog_path_style: 'fog_path_style',
       fog_storage_options: {},
-      fog_public: false,
+      fog_public: false
     }
   end
 
@@ -57,16 +56,16 @@ RSpec.describe SitemapGenerator::S3Adapter do
       expect(adapter.instance_variable_get(:@fog_region)).to eq('fog_region')
       expect(adapter.instance_variable_get(:@fog_path_style)).to eq('fog_path_style')
       expect(adapter.instance_variable_get(:@fog_storage_options)).to eq(options[:fog_storage_options])
-      expect(adapter.instance_variable_get(:@fog_public)).to eq(false)
+      expect(adapter.instance_variable_get(:@fog_public)).to be(false)
     end
 
-    context 'fog_public' do
+    context 'when fog_public is nil' do
       let(:options) do
         { fog_public: nil }
       end
 
       it 'defaults to true' do
-        expect(adapter.instance_variable_get(:@fog_public)).to eq(true)
+        expect(adapter.instance_variable_get(:@fog_public)).to be(true)
       end
 
       context 'when a string value' do
@@ -75,7 +74,7 @@ RSpec.describe SitemapGenerator::S3Adapter do
         end
 
         it 'converts to a boolean' do
-          expect(adapter.instance_variable_get(:@fog_public)).to eq(false)
+          expect(adapter.instance_variable_get(:@fog_public)).to be(false)
         end
       end
     end
@@ -88,7 +87,7 @@ RSpec.describe SitemapGenerator::S3Adapter do
         body: instance_of(File),
         key: 'test/sitemap.xml.gz',
         public: false,
-        content_type: 'application/x-gzip',
+        content_type: 'application/x-gzip'
       )
       adapter.write(location, 'payload')
     end

--- a/spec/sitemap_generator/adapters/wave_adapter_spec.rb
+++ b/spec/sitemap_generator/adapters/wave_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator::WaveAdapter' do

--- a/spec/sitemap_generator/application_spec.rb
+++ b/spec/sitemap_generator/application_spec.rb
@@ -1,20 +1,24 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::Application do
   before do
     stub_const('Rails::VERSION', '1')
-    @app = SitemapGenerator::Application.new
+    @app = described_class.new
   end
 
   describe 'is_at_least_rails3?' do
-    tests = {
-      :nil => false,
-      '2.3.11' => false,
-      '3.0.1' => true,
-      '3.0.11' => true
-    }
+    let(:tests) do
+      {
+        :nil => false,
+        '2.3.11' => false,
+        '3.0.1' => true,
+        '3.0.11' => true
+      }
+    end
 
-    it 'should identify the rails version correctly' do
+    it 'identifies the rails version correctly' do
       tests.each do |version, result|
         expect(Rails).to receive(:version).and_return(version)
         expect(@app.is_at_least_rails3?).to eq(result)
@@ -28,10 +32,10 @@ RSpec.describe SitemapGenerator::Application do
       expect(Rails).to receive(:root).and_return(@root).at_least(:once)
     end
 
-    it 'should use the Rails.root' do
+    it 'uses the Rails.root' do
       expect(@app.root).to be_a(Pathname)
       expect(@app.root.to_s).to eq(@root)
-      expect((@app.root + 'public/').to_s).to eq(File.join(@root, 'public/'))
+      expect("#{@app.root}/public/").to eq(File.join(@root, 'public/'))
     end
   end
 
@@ -40,14 +44,14 @@ RSpec.describe SitemapGenerator::Application do
       hide_const('Rails')
     end
 
-    it 'should not be Rails' do
+    it 'is not Rails' do
       expect(@app.is_rails?).to be(false)
     end
 
-    it 'should use the current working directory' do
+    it 'uses the current working directory' do
       expect(@app.root).to be_a(Pathname)
       expect(@app.root.to_s).to eq(Dir.getwd)
-      expect((@app.root + 'public/').to_s).to eq(File.join(Dir.getwd, 'public/'))
+      expect("#{@app.root}/public/").to eq(File.join(Dir.getwd, 'public/'))
     end
   end
 end

--- a/spec/sitemap_generator/application_spec.rb
+++ b/spec/sitemap_generator/application_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SitemapGenerator::Application do
     it 'uses the Rails.root' do
       expect(@app.root).to be_a(Pathname)
       expect(@app.root.to_s).to eq(@root)
-      expect("#{@app.root}/public/").to eq(File.join(@root, 'public/'))
+      expect(@app.root.join('public/').to_s).to eq(File.join(@root, 'public/'))
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe SitemapGenerator::Application do
     it 'uses the current working directory' do
       expect(@app.root).to be_a(Pathname)
       expect(@app.root.to_s).to eq(Dir.getwd)
-      expect("#{@app.root}/public/").to eq(File.join(Dir.getwd, 'public/'))
+      expect(@app.root.join('public/').to_s).to eq(File.join(Dir.getwd, 'public/'))
     end
   end
 end

--- a/spec/sitemap_generator/builder/sitemap_file_spec.rb
+++ b/spec/sitemap_generator/builder/sitemap_file_spec.rb
@@ -1,36 +1,41 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator::Builder::SitemapFile' do
-  let(:location) { SitemapGenerator::SitemapLocation.new(:namer => SitemapGenerator::SimpleNamer.new(:sitemap, :start => 2, :zero => 1), :public_path => 'tmp/', :sitemaps_path => 'test/', :host => 'http://example.com/') }
-  let(:sitemap)  { SitemapGenerator::Builder::SitemapFile.new(location) }
+  let(:location) do
+    SitemapGenerator::SitemapLocation.new(namer: SitemapGenerator::SimpleNamer.new(:sitemap, start: 2, zero: 1),
+                                          public_path: 'tmp/', sitemaps_path: 'test/', host: 'http://example.com/')
+  end
+  let(:sitemap) { SitemapGenerator::Builder::SitemapFile.new(location) }
 
-  it 'should have a default namer' do
+  it 'has a default namer' do
     sitemap = SitemapGenerator::Builder::SitemapFile.new
     expect(sitemap.location.filename).to eq('sitemap1.xml.gz')
   end
 
-  it 'should return the name of the sitemap file' do
+  it 'returns the name of the sitemap file' do
     expect(sitemap.location.filename).to eq('sitemap1.xml.gz')
   end
 
-  it 'should return the URL' do
+  it 'returns the URL' do
     expect(sitemap.location.url).to eq('http://example.com/test/sitemap1.xml.gz')
   end
 
-  it 'should return the path' do
+  it 'returns the path' do
     expect(sitemap.location.path).to eq(File.expand_path('tmp/test/sitemap1.xml.gz'))
   end
 
-  it 'should be empty' do
+  it 'is empty' do
     expect(sitemap.empty?).to be(true)
     expect(sitemap.link_count).to eq(0)
   end
 
-  it 'should not be finalized' do
+  it 'is not finalized' do
     expect(sitemap.finalized?).to be(false)
   end
 
-  it 'should raise if no default host is set' do
+  it 'raises if no default host is set' do
     expect { SitemapGenerator::Builder::SitemapFile.new.location.url }.to raise_error(SitemapGenerator::SitemapError)
   end
 
@@ -70,23 +75,23 @@ RSpec.describe 'SitemapGenerator::Builder::SitemapFile' do
       new_sitemap
     end
 
-    it 'should inherit the same options' do
+    it 'inherits the same options' do
       # The name is the same because the original sitemap was not finalized
       expect(new_sitemap.location.url).to eq('http://example.com/test/sitemap1.xml.gz')
       expect(new_sitemap.location.path).to eq(File.expand_path('tmp/test/sitemap1.xml.gz'))
     end
 
-    it 'should not share the same location instance' do
+    it 'does not share the same location instance' do
       expect(new_sitemap.location).not_to be(original_sitemap.location)
     end
 
-    it 'should inherit the same namer instance' do
+    it 'inherits the same namer instance' do
       expect(new_sitemap.location.namer).to eq(original_sitemap.location.namer)
     end
   end
 
   describe 'reserve_name' do
-    it 'should reserve the name from the location' do
+    it 'reserves the name from the location' do
       expect(sitemap.reserved_name?).to be(false)
       expect(sitemap.location).to receive(:reserve_name).and_return('name')
       sitemap.reserve_name
@@ -94,7 +99,7 @@ RSpec.describe 'SitemapGenerator::Builder::SitemapFile' do
       expect(sitemap.instance_variable_get(:@reserved_name)).to eq('name')
     end
 
-    it 'should be safe to call multiple times' do
+    it 'is safe to call multiple times' do
       expect(sitemap.location).to receive(:reserve_name).and_return('name').once
       sitemap.reserve_name
       sitemap.reserve_name
@@ -102,15 +107,17 @@ RSpec.describe 'SitemapGenerator::Builder::SitemapFile' do
   end
 
   describe 'add' do
-    it 'should use the host provided' do
-      url = SitemapGenerator::Builder::SitemapUrl.new('/one', :host => 'http://newhost.com/')
-      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new).with('/one', { :host => 'http://newhost.com' }).and_return(url)
-      sitemap.add '/one', :host => 'http://newhost.com'
+    it 'uses the host provided' do
+      url = SitemapGenerator::Builder::SitemapUrl.new('/one', host: 'http://newhost.com/')
+      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new)
+        .with('/one', { host: 'http://newhost.com' }).and_return(url)
+      sitemap.add '/one', host: 'http://newhost.com'
     end
 
-    it 'should use the host from the location' do
-      url = SitemapGenerator::Builder::SitemapUrl.new('/one', :host => 'http://example.com/')
-      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new).with('/one', { :host => 'http://example.com/' }).and_return(url)
+    it 'uses the host from the location' do
+      url = SitemapGenerator::Builder::SitemapUrl.new('/one', host: 'http://example.com/')
+      expect(SitemapGenerator::Builder::SitemapUrl).to receive(:new)
+        .with('/one', { host: 'http://example.com/' }).and_return(url)
       sitemap.add '/one'
     end
   end

--- a/spec/sitemap_generator/builder/sitemap_index_file_spec.rb
+++ b/spec/sitemap_generator/builder/sitemap_index_file_spec.rb
@@ -1,31 +1,36 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator::Builder::SitemapIndexFile' do
-  let(:location) { SitemapGenerator::SitemapLocation.new(:filename => 'sitemap.xml.gz', :public_path => '/public/', :host => 'http://example.com/') }
-  let(:index)    { SitemapGenerator::Builder::SitemapIndexFile.new(location) }
+  let(:location) do
+    SitemapGenerator::SitemapLocation.new(filename: 'sitemap.xml.gz', public_path: '/public/',
+                                          host: 'http://example.com/')
+  end
+  let(:index) { SitemapGenerator::Builder::SitemapIndexFile.new(location) }
 
   before do
     index.location[:sitemaps_path] = 'test/'
   end
 
-  it 'should return the URL' do
+  it 'returns the URL' do
     expect(index.location.url).to eq('http://example.com/test/sitemap.xml.gz')
   end
 
-  it 'should return the path' do
+  it 'returns the path' do
     expect(index.location.path).to eq('/public/test/sitemap.xml.gz')
   end
 
-  it 'should be empty' do
+  it 'is empty' do
     expect(index.empty?).to be(true)
     expect(index.link_count).to eq(0)
   end
 
-  it 'should not have a last modification data' do
+  it 'does not have a last modification data' do
     expect(index.lastmod).to be_nil
   end
 
-  it 'should not be finalized' do
+  it 'is not finalized' do
     expect(index.finalized?).to be(false)
   end
 
@@ -33,20 +38,20 @@ RSpec.describe 'SitemapGenerator::Builder::SitemapIndexFile' do
     expect(index.location.filename).to eq('sitemap.xml.gz')
   end
 
-  it 'should have a default namer' do
+  it 'has a default namer' do
     index = SitemapGenerator::Builder::SitemapIndexFile.new
     expect(index.location.filename).to eq('sitemap.xml.gz')
   end
 
   describe 'link_count' do
-    it 'should return the link count' do
+    it 'returns the link count' do
       index.instance_variable_set(:@link_count, 10)
       expect(index.link_count).to eq(10)
     end
   end
 
   describe 'create_index?' do
-    it 'should return false' do
+    it 'returns false' do
       index.location[:create_index] = false
       expect(index.create_index?).to be(false)
 
@@ -54,7 +59,7 @@ RSpec.describe 'SitemapGenerator::Builder::SitemapIndexFile' do
       expect(index.create_index?).to be(false)
     end
 
-    it 'should return true' do
+    it 'returns true' do
       index.location[:create_index] = true
       expect(index.create_index?).to be(true)
 
@@ -73,25 +78,27 @@ RSpec.describe 'SitemapGenerator::Builder::SitemapIndexFile' do
   end
 
   describe 'add' do
-    it 'should use the host provided' do
-      url = SitemapGenerator::Builder::SitemapIndexUrl.new('/one', :host => 'http://newhost.com/')
-      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new).with('/one', { :host => 'http://newhost.com' }).and_return(url)
-      index.add '/one', :host => 'http://newhost.com'
+    it 'uses the host provided' do
+      url = SitemapGenerator::Builder::SitemapIndexUrl.new('/one', host: 'http://newhost.com/')
+      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new)
+        .with('/one', { host: 'http://newhost.com' }).and_return(url)
+      index.add '/one', host: 'http://newhost.com'
     end
 
-    it 'should use the host from the location' do
-      url = SitemapGenerator::Builder::SitemapIndexUrl.new('/one', :host => 'http://example.com/')
-      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new).with('/one', { :host => 'http://example.com/' }).and_return(url)
+    it 'uses the host from the location' do
+      url = SitemapGenerator::Builder::SitemapIndexUrl.new('/one', host: 'http://example.com/')
+      expect(SitemapGenerator::Builder::SitemapIndexUrl).to receive(:new)
+        .with('/one', { host: 'http://example.com/' }).and_return(url)
       index.add '/one'
     end
 
     describe 'when adding manually' do
-      it 'should reserve a name' do
+      it 'reserves a name' do
         expect(index).to receive(:reserve_name)
         index.add '/link'
       end
 
-      it 'should create index' do
+      it 'creates index' do
         expect(index.create_index?).to be(false)
         index.add '/one'
         expect(index.create_index?).to be(true)

--- a/spec/sitemap_generator/builder/sitemap_url_spec.rb
+++ b/spec/sitemap_generator/builder/sitemap_url_spec.rb
@@ -242,7 +242,7 @@ RSpec.describe SitemapGenerator::Builder::SitemapUrl do
   end
 
   describe '#initialize' do
-    describe 'lastmod' do
+    context 'when lastmod is not given' do
       let(:frozen_time) { Time.at(1_000_000).utc }
 
       before do

--- a/spec/sitemap_generator/builder/sitemap_url_spec.rb
+++ b/spec/sitemap_generator/builder/sitemap_url_spec.rb
@@ -132,23 +132,22 @@ RSpec.describe SitemapGenerator::Builder::SitemapUrl do
       expect(new_url.send(:w3c_date, DateTime.new(0))).to eq('0000-01-01T00:00:00+00:00')
     end
 
-
     it 'returns strings unmodified' do
       expect(new_url.send(:w3c_date, '2010-01-01')).to eq('2010-01-01')
     end
 
     it 'tries to convert to utc' do
       time = Time.at(0)
-      expect(time).to receive(:respond_to?).and_return(false) # rubocop:disable RSpec/StubbedMock, RSpec/MessageSpies
-      expect(time).to receive(:respond_to?).and_return(true) # rubocop:disable RSpec/StubbedMock, RSpec/MessageSpies
+      expect(time).to receive(:respond_to?).and_return(false)
+      expect(time).to receive(:respond_to?).and_return(true)
       expect(new_url.send(:w3c_date, time)).to eq('1970-01-01T00:00:00+00:00')
     end
 
     it 'includes timezone for objects which do not respond to iso8601 or utc' do
       time = Time.at(0)
-      expect(time).to receive(:respond_to?).and_return(false) # rubocop:disable RSpec/StubbedMock, RSpec/MessageSpies
-      expect(time).to receive(:respond_to?).and_return(false) # rubocop:disable RSpec/StubbedMock, RSpec/MessageSpies
-      expect(time).to receive(:strftime).and_return(+'+0800', '1970-01-01T00:00:00') # rubocop:disable RSpec/MessageSpies
+      expect(time).to receive(:respond_to?).and_return(false)
+      expect(time).to receive(:respond_to?).and_return(false)
+      expect(time).to receive(:strftime).and_return(+'+0800', '1970-01-01T00:00:00')
       expect(new_url.send(:w3c_date, time)).to eq('1970-01-01T00:00:00+08:00')
     end
 
@@ -243,7 +242,7 @@ RSpec.describe SitemapGenerator::Builder::SitemapUrl do
   end
 
   describe '#initialize' do
-    context 'lastmod' do
+    describe 'lastmod' do
       let(:frozen_time) { Time.at(1_000_000).utc }
 
       before do
@@ -258,7 +257,7 @@ RSpec.describe SitemapGenerator::Builder::SitemapUrl do
 
     context 'when path contains non-ASCII characters' do
       it 'percent-encodes non-ASCII characters in the loc' do
-        url = SitemapGenerator::Builder::SitemapUrl.new('/RFC3986ü中文', host: 'http://example.com', lastmod: nil)
+        url = described_class.new('/RFC3986ü中文', host: 'http://example.com', lastmod: nil)
         expect(url[:loc]).to eq('http://example.com/RFC3986%C3%BC%E4%B8%AD%E6%96%87')
       end
     end
@@ -282,7 +281,7 @@ RSpec.describe SitemapGenerator::Builder::SitemapUrl do
   describe 'alternates' do
     let(:xml_doc) do
       Nokogiri::XML(
-        "<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' "         "xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{url.to_xml}</root>"
+        "<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{url.to_xml}</root>"
       )
     end
     let(:alternate_link) { xml_doc.xpath('//xhtml:link', 'xhtml' => 'http://www.w3.org/1999/xhtml').first }

--- a/spec/sitemap_generator/core_ext/bigdecimal_spec.rb
+++ b/spec/sitemap_generator/core_ext/bigdecimal_spec.rb
@@ -1,19 +1,22 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'bigdecimal'
 
 RSpec.describe SitemapGenerator::BigDecimal do
   describe 'to_yaml' do
-    it 'should serialize correctly' do
-      expect(SitemapGenerator::BigDecimal.new('100000.30020320320000000000000000000000000000001').to_yaml).to match(/^--- 100000\.30020320320000000000000000000000000000001\n/)
-      expect(SitemapGenerator::BigDecimal.new('Infinity').to_yaml).to match(/^--- \.Inf\n/)
-      expect(SitemapGenerator::BigDecimal.new('NaN').to_yaml).to match(/^--- \.NaN\n/)
-      expect(SitemapGenerator::BigDecimal.new('-Infinity').to_yaml).to match(/^--- -\.Inf\n/)
+    it 'serializes correctly' do
+      big_number = '100000.30020320320000000000000000000000000000001'
+      expect(described_class.new(big_number).to_yaml).to match(/^--- #{Regexp.escape(big_number)}\n/)
+      expect(described_class.new('Infinity').to_yaml).to match(/^--- \.Inf\n/)
+      expect(described_class.new('NaN').to_yaml).to match(/^--- \.NaN\n/)
+      expect(described_class.new('-Infinity').to_yaml).to match(/^--- -\.Inf\n/)
     end
   end
 
   describe 'to_d' do
-    it 'should convert correctly' do
-      bd = SitemapGenerator::BigDecimal.new '10'
+    it 'converts correctly' do
+      bd = described_class.new '10'
       expect(bd.to_d).to eq(bd)
     end
   end

--- a/spec/sitemap_generator/core_ext/numeric_spec.rb
+++ b/spec/sitemap_generator/core_ext/numeric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::Numeric do
@@ -6,18 +8,18 @@ RSpec.describe SitemapGenerator::Numeric do
   end
 
   describe 'bytes' do
-    it 'should define equality of different units' do
+    it 'defines equality of different units' do
       relationships = {
-        numeric(  1024).bytes     => numeric(  1).kilobyte,
-        numeric(  1024).kilobytes => numeric(  1).megabyte,
+        numeric(1024).bytes => numeric(1).kilobyte,
+        numeric(1024).kilobytes => numeric(1).megabyte,
         numeric(3584.0).kilobytes => numeric(3.5).megabytes,
         numeric(3584.0).megabytes => numeric(3.5).gigabytes,
-        numeric(1).kilobyte ** 4  => numeric(  1).terabyte,
-        numeric(1024).kilobytes + numeric(2).megabytes =>   numeric(3).megabytes,
-        numeric(             2).gigabytes / 4 => numeric(512).megabytes,
-        numeric(256).megabytes * 20 + numeric( 5).gigabytes => numeric(10).gigabytes,
-        numeric(1).kilobyte ** 5 => numeric(1).petabyte,
-        numeric(1).kilobyte ** 6 => numeric(1).exabyte
+        numeric(1).kilobyte**4 => numeric(1).terabyte,
+        numeric(1024).kilobytes + numeric(2).megabytes => numeric(3).megabytes,
+        numeric(2).gigabytes / 4 => numeric(512).megabytes,
+        (numeric(256).megabytes * 20) + numeric(5).gigabytes => numeric(10).gigabytes,
+        numeric(1).kilobyte**5 => numeric(1).petabyte,
+        numeric(1).kilobyte**6 => numeric(1).exabyte
       }
 
       relationships.each do |left, right|
@@ -25,19 +27,19 @@ RSpec.describe SitemapGenerator::Numeric do
       end
     end
 
-    it 'should represent units as bytes' do
-      expect(numeric(3).megabytes).to eq(3145728)
-      expect(numeric(3).megabyte) .to eq(3145728)
+    it 'represents units as bytes' do
+      expect(numeric(3).megabytes).to eq(3_145_728)
+      expect(numeric(3).megabyte).to eq(3_145_728)
       expect(numeric(3).kilobytes).to eq(3072)
-      expect(numeric(3).kilobyte) .to eq(3072)
-      expect(numeric(3).gigabytes).to eq(3221225472)
-      expect(numeric(3).gigabyte) .to eq(3221225472)
-      expect(numeric(3).terabytes).to eq(3298534883328)
-      expect(numeric(3).terabyte) .to eq(3298534883328)
-      expect(numeric(3).petabytes).to eq(3377699720527872)
-      expect(numeric(3).petabyte) .to eq(3377699720527872)
-      expect(numeric(3).exabytes) .to eq(3458764513820540928)
-      expect(numeric(3).exabyte)  .to eq(3458764513820540928)
+      expect(numeric(3).kilobyte).to eq(3072)
+      expect(numeric(3).gigabytes).to eq(3_221_225_472)
+      expect(numeric(3).gigabyte).to eq(3_221_225_472)
+      expect(numeric(3).terabytes).to eq(3_298_534_883_328)
+      expect(numeric(3).terabyte).to eq(3_298_534_883_328)
+      expect(numeric(3).petabytes).to eq(3_377_699_720_527_872)
+      expect(numeric(3).petabyte).to eq(3_377_699_720_527_872)
+      expect(numeric(3).exabytes).to eq(3_458_764_513_820_540_928)
+      expect(numeric(3).exabyte).to eq(3_458_764_513_820_540_928)
     end
   end
 end

--- a/spec/sitemap_generator/helpers/number_helper_spec.rb
+++ b/spec/sitemap_generator/helpers/number_helper_spec.rb
@@ -22,7 +22,7 @@ end
 RSpec.describe SitemapGenerator::Helpers::NumberHelper do
   include described_class
 
-  it 'number_with_delimiters' do
+  it 'formats a number with a delimiter' do
     expect(number_with_delimiter(12_345_678)).to eq('12,345,678')
     expect(number_with_delimiter(0)).to eq('0')
     expect(number_with_delimiter(123)).to eq('123')
@@ -35,14 +35,14 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
     expect(number_with_delimiter('123456.78')).to eq('123,456.78')
   end
 
-  it 'number_with_delimiter_with_options_hashes' do
+  it 'formats a number with a delimiter using custom options' do
     expect(number_with_delimiter(12_345_678, delimiter: ' ')).to eq('12 345 678')
     expect(number_with_delimiter(12_345_678.05, separator: '-')).to eq('12,345,678-05')
     expect(number_with_delimiter(12_345_678.05, separator: ',', delimiter: '.')).to eq('12.345.678,05')
     expect(number_with_delimiter(12_345_678.05, delimiter: '.', separator: ',')).to eq('12.345.678,05')
   end
 
-  it 'number_with_precisions' do
+  it 'formats a number with precision' do
     expect(number_with_precision(-111.2346)).to eq('-111.235')
     expect(number_with_precision(111.2346)).to eq('111.235')
     expect(number_with_precision(31.825, precision: 2)).to eq('31.83')
@@ -65,12 +65,12 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
     expect(number_with_precision(10.995, precision: 2)).to eq('11.00')
   end
 
-  it 'number_with_precision_with_custom_delimiter_and_separators' do
+  it 'formats a number with precision using a custom delimiter and separator' do
     expect(number_with_precision(31.825, precision: 2, separator: ',')).to eq('31,83')
     expect(number_with_precision(1231.825, precision: 2, separator: ',', delimiter: '.')).to eq('1.231,83')
   end
 
-  it 'number_with_precision_with_significant_digitses' do
+  it 'formats a number with precision using significant digits' do
     expect(number_with_precision(123_987, precision: 3, significant: true)).to eq('124000')
     expect(number_with_precision(123_987_876, precision: 2, significant: true)).to eq('120000000')
     expect(number_with_precision('43523', precision: 1, significant: true)).to eq('40000')
@@ -93,7 +93,7 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
     expect(number_with_precision(10.995, precision: 3, significant: true)).to eq('11.0')
   end
 
-  it 'number_with_precision_with_strip_insignificant_zeroses' do
+  it 'strips insignificant zeros when formatting with precision' do
     expect(number_with_precision(9775.43, precision: 4, strip_insignificant_zeros: true)).to eq('9775.43')
     expect(number_with_precision(9775.2, precision: 6, significant: true,
                                          strip_insignificant_zeros: true)).to eq('9775.2')
@@ -101,7 +101,7 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
                                     strip_insignificant_zeros: true)).to eq('0')
   end
 
-  it 'number_with_precision_with_significant_true_and_zero_precisions' do
+  it 'treats significant as false when precision is zero' do
     # Zero precision with significant is a mistake (would always return zero),
     # so we treat it as if significant was false (increases backwards compatibily for number_to_human_size)
     expect(number_with_precision(123.987, precision: 0, significant: true)).to eq('124')
@@ -109,7 +109,7 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
     expect(number_with_precision('12.3', precision: 0, significant: true)).to eq('12')
   end
 
-  it 'number_to_human_sizes' do
+  it 'formats a number as a human-readable size' do
     expect(number_to_human_size(0)).to eq('0 Bytes')
     expect(number_to_human_size(1)).to eq('1 Byte')
     expect(number_to_human_size(3.14159265)).to eq('3 Bytes')
@@ -134,7 +134,7 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
     expect(number_to_human_size(10)).to eq('10 Bytes')
   end
 
-  it 'number_to_human_size_with_options_hashes' do
+  it 'formats a human-readable size using custom options' do
     expect(number_to_human_size(1_234_567, precision: 2)).to eq('1.2 MB')
     expect(number_to_human_size(3.14159265, precision: 4)).to eq('3 Bytes')
     expect(number_to_human_size(kilobytes(1.0123), precision: 2)).to eq('1 KB')
@@ -152,7 +152,7 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
     expect(number_to_human_size(kilobytes(1.0123), precision: 0, significant: true)).to eq('1 KB')
   end
 
-  it 'number_to_human_size_with_custom_delimiter_and_separators' do
+  it 'formats a human-readable size using a custom delimiter and separator' do
     expect(number_to_human_size(kilobytes(1.0123), precision: 3,
                                                    separator: ',')).to eq('1,01 KB')
     expect(number_to_human_size(kilobytes(1.0100), precision: 4,
@@ -161,20 +161,20 @@ RSpec.describe SitemapGenerator::Helpers::NumberHelper do
                                                    separator: ',')).to eq('1.000,1 TB')
   end
 
-  it 'number_helpers_should_return_nil_when_given_nils' do
+  it 'returns nil when given nil' do
     expect(number_with_delimiter(nil)).to be_nil
     expect(number_with_precision(nil)).to be_nil
     expect(number_to_human_size(nil)).to be_nil
   end
 
-  it 'number_helpers_should_return_non_numeric_param_unchangeds' do
+  it 'returns non-numeric input unchanged' do
     expect(number_with_delimiter('x')).to eq('x')
     expect(number_with_precision('x.')).to eq('x.')
     expect(number_with_precision('x')).to eq('x')
     expect(number_to_human_size('x')).to eq('x')
   end
 
-  it 'number_helpers_should_raise_error_if_invalid_when_specifieds' do
+  it 'raises an error for invalid input when raise is specified' do
     expect do
       number_to_human_size('x', raise: true)
     end.to raise_error(SitemapGenerator::Helpers::NumberHelper::InvalidNumberError)

--- a/spec/sitemap_generator/helpers/number_helper_spec.rb
+++ b/spec/sitemap_generator/helpers/number_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sitemap_generator/helpers/number_helper'
 
@@ -18,177 +20,184 @@ def terabytes(number)
 end
 
 RSpec.describe SitemapGenerator::Helpers::NumberHelper do
-  include SitemapGenerator::Helpers::NumberHelper
+  include described_class
 
-  it 'should number_with_delimiter' do
-    expect(number_with_delimiter(12345678)).to eq('12,345,678')
+  it 'number_with_delimiters' do
+    expect(number_with_delimiter(12_345_678)).to eq('12,345,678')
     expect(number_with_delimiter(0)).to eq('0')
     expect(number_with_delimiter(123)).to eq('123')
-    expect(number_with_delimiter(123456)).to eq('123,456')
-    expect(number_with_delimiter(123456.78)).to eq('123,456.78')
-    expect(number_with_delimiter(123456.789)).to eq('123,456.789')
-    expect(number_with_delimiter(123456.78901)).to eq('123,456.78901')
-    expect(number_with_delimiter(123456789.78901)).to eq('123,456,789.78901')
+    expect(number_with_delimiter(123_456)).to eq('123,456')
+    expect(number_with_delimiter(123_456.78)).to eq('123,456.78')
+    expect(number_with_delimiter(123_456.789)).to eq('123,456.789')
+    expect(number_with_delimiter(123_456.78901)).to eq('123,456.78901')
+    expect(number_with_delimiter(123_456_789.78901)).to eq('123,456,789.78901')
     expect(number_with_delimiter(0.78901)).to eq('0.78901')
     expect(number_with_delimiter('123456.78')).to eq('123,456.78')
   end
 
-  it 'should number_with_delimiter_with_options_hash' do
-    expect(number_with_delimiter(12345678, :delimiter => ' ')).to eq('12 345 678')
-    expect(number_with_delimiter(12345678.05, :separator => '-')).to eq('12,345,678-05')
-    expect(number_with_delimiter(12345678.05, :separator => ',', :delimiter => '.')).to eq('12.345.678,05')
-    expect(number_with_delimiter(12345678.05, :delimiter => '.', :separator => ',')).to eq('12.345.678,05')
+  it 'number_with_delimiter_with_options_hashes' do
+    expect(number_with_delimiter(12_345_678, delimiter: ' ')).to eq('12 345 678')
+    expect(number_with_delimiter(12_345_678.05, separator: '-')).to eq('12,345,678-05')
+    expect(number_with_delimiter(12_345_678.05, separator: ',', delimiter: '.')).to eq('12.345.678,05')
+    expect(number_with_delimiter(12_345_678.05, delimiter: '.', separator: ',')).to eq('12.345.678,05')
   end
 
-  it 'should number_with_precision' do
+  it 'number_with_precisions' do
     expect(number_with_precision(-111.2346)).to eq('-111.235')
     expect(number_with_precision(111.2346)).to eq('111.235')
-    expect(number_with_precision(31.825, :precision => 2)).to eq('31.83')
-    expect(number_with_precision(111.2346, :precision => 2)).to eq('111.23')
-    expect(number_with_precision(111, :precision => 2)).to eq('111.00')
+    expect(number_with_precision(31.825, precision: 2)).to eq('31.83')
+    expect(number_with_precision(111.2346, precision: 2)).to eq('111.23')
+    expect(number_with_precision(111, precision: 2)).to eq('111.00')
     expect(number_with_precision('111.2346')).to eq('111.235')
-    expect(number_with_precision('31.825', :precision => 2)).to eq('31.83')
-    expect(number_with_precision((32.6751 * 100.00), :precision => 0)).to eq('3268')
-    expect(number_with_precision(111.50, :precision => 0)).to eq('112')
-    expect(number_with_precision(1234567891.50, :precision => 0)).to eq('1234567892')
-    expect(number_with_precision(0, :precision => 0)).to eq('0')
-    expect(number_with_precision(0.001, :precision => 5)).to eq('0.00100')
-    expect(number_with_precision(0.00111, :precision => 3)).to eq('0.001')
+    expect(number_with_precision('31.825', precision: 2)).to eq('31.83')
+    expect(number_with_precision(32.6751 * 100.00, precision: 0)).to eq('3268')
+    expect(number_with_precision(111.50, precision: 0)).to eq('112')
+    expect(number_with_precision(1_234_567_891.50, precision: 0)).to eq('1234567892')
+    expect(number_with_precision(0, precision: 0)).to eq('0')
+    expect(number_with_precision(0.001, precision: 5)).to eq('0.00100')
+    expect(number_with_precision(0.00111, precision: 3)).to eq('0.001')
     # Odd difference between Ruby versions
     if RUBY_VERSION < '1.9.3'
-      expect(number_with_precision(9.995, :precision => 2)).to eq('9.99')
+      expect(number_with_precision(9.995, precision: 2)).to eq('9.99')
     else
-      expect(number_with_precision(9.995, :precision => 2)).to eq('10.00')
+      expect(number_with_precision(9.995, precision: 2)).to eq('10.00')
     end
-    expect(number_with_precision(10.995, :precision => 2)).to eq('11.00')
+    expect(number_with_precision(10.995, precision: 2)).to eq('11.00')
   end
 
-  it 'should number_with_precision_with_custom_delimiter_and_separator' do
-    expect(number_with_precision(31.825, :precision => 2, :separator => ',')).to eq('31,83')
-    expect(number_with_precision(1231.825, :precision => 2, :separator => ',', :delimiter => '.')).to eq('1.231,83')
+  it 'number_with_precision_with_custom_delimiter_and_separators' do
+    expect(number_with_precision(31.825, precision: 2, separator: ',')).to eq('31,83')
+    expect(number_with_precision(1231.825, precision: 2, separator: ',', delimiter: '.')).to eq('1.231,83')
   end
 
-  it 'should number_with_precision_with_significant_digits' do
-    expect(number_with_precision(123987, :precision => 3, :significant => true)).to eq('124000')
-    expect(number_with_precision(123987876, :precision => 2, :significant => true )).to eq('120000000')
-    expect(number_with_precision('43523', :precision => 1, :significant => true )).to eq('40000')
-    expect(number_with_precision(9775, :precision => 4, :significant => true )).to eq('9775')
-    expect(number_with_precision(5.3923, :precision => 2, :significant => true )).to eq('5.4')
-    expect(number_with_precision(5.3923, :precision => 1, :significant => true )).to eq('5')
-    expect(number_with_precision(1.232, :precision => 1, :significant => true )).to eq('1')
-    expect(number_with_precision(7, :precision => 1, :significant => true )).to eq('7')
-    expect(number_with_precision(1, :precision => 1, :significant => true )).to eq('1')
-    expect(number_with_precision(52.7923, :precision => 2, :significant => true )).to eq('53')
-    expect(number_with_precision(9775, :precision => 6, :significant => true )).to eq('9775.00')
-    expect(number_with_precision(5.3929, :precision => 7, :significant => true )).to eq('5.392900')
-    expect(number_with_precision(0, :precision => 2, :significant => true )).to eq('0.0')
-    expect(number_with_precision(0, :precision => 1, :significant => true )).to eq('0')
-    expect(number_with_precision(0.0001, :precision => 1, :significant => true )).to eq('0.0001')
-    expect(number_with_precision(0.0001, :precision => 3, :significant => true )).to eq('0.000100')
-    expect(number_with_precision(0.0001111, :precision => 1, :significant => true )).to eq('0.0001')
-    expect(number_with_precision(9.995, :precision => 3, :significant => true)).to eq('10.0')
-    expect(number_with_precision(9.994, :precision => 3, :significant => true)).to eq('9.99')
-    expect(number_with_precision(10.995, :precision => 3, :significant => true)).to eq('11.0')
+  it 'number_with_precision_with_significant_digitses' do
+    expect(number_with_precision(123_987, precision: 3, significant: true)).to eq('124000')
+    expect(number_with_precision(123_987_876, precision: 2, significant: true)).to eq('120000000')
+    expect(number_with_precision('43523', precision: 1, significant: true)).to eq('40000')
+    expect(number_with_precision(9775, precision: 4, significant: true)).to eq('9775')
+    expect(number_with_precision(5.3923, precision: 2, significant: true)).to eq('5.4')
+    expect(number_with_precision(5.3923, precision: 1, significant: true)).to eq('5')
+    expect(number_with_precision(1.232, precision: 1, significant: true)).to eq('1')
+    expect(number_with_precision(7, precision: 1, significant: true)).to eq('7')
+    expect(number_with_precision(1, precision: 1, significant: true)).to eq('1')
+    expect(number_with_precision(52.7923, precision: 2, significant: true)).to eq('53')
+    expect(number_with_precision(9775, precision: 6, significant: true)).to eq('9775.00')
+    expect(number_with_precision(5.3929, precision: 7, significant: true)).to eq('5.392900')
+    expect(number_with_precision(0, precision: 2, significant: true)).to eq('0.0')
+    expect(number_with_precision(0, precision: 1, significant: true)).to eq('0')
+    expect(number_with_precision(0.0001, precision: 1, significant: true)).to eq('0.0001')
+    expect(number_with_precision(0.0001, precision: 3, significant: true)).to eq('0.000100')
+    expect(number_with_precision(0.0001111, precision: 1, significant: true)).to eq('0.0001')
+    expect(number_with_precision(9.995, precision: 3, significant: true)).to eq('10.0')
+    expect(number_with_precision(9.994, precision: 3, significant: true)).to eq('9.99')
+    expect(number_with_precision(10.995, precision: 3, significant: true)).to eq('11.0')
   end
 
-  it 'should number_with_precision_with_strip_insignificant_zeros' do
-    expect(number_with_precision(9775.43, :precision => 4, :strip_insignificant_zeros => true )).to eq('9775.43')
-    expect(number_with_precision(9775.2, :precision => 6, :significant => true, :strip_insignificant_zeros => true )).to eq('9775.2')
-    expect(number_with_precision(0, :precision => 6, :significant => true, :strip_insignificant_zeros => true )).to eq('0')
+  it 'number_with_precision_with_strip_insignificant_zeroses' do
+    expect(number_with_precision(9775.43, precision: 4, strip_insignificant_zeros: true)).to eq('9775.43')
+    expect(number_with_precision(9775.2, precision: 6, significant: true,
+                                         strip_insignificant_zeros: true)).to eq('9775.2')
+    expect(number_with_precision(0, precision: 6, significant: true,
+                                    strip_insignificant_zeros: true)).to eq('0')
   end
 
-  it 'should number_with_precision_with_significant_true_and_zero_precision' do
+  it 'number_with_precision_with_significant_true_and_zero_precisions' do
     # Zero precision with significant is a mistake (would always return zero),
     # so we treat it as if significant was false (increases backwards compatibily for number_to_human_size)
-    expect(number_with_precision(123.987, :precision => 0, :significant => true)).to eq('124')
-    expect(number_with_precision(12, :precision => 0, :significant => true )).to eq('12')
-    expect(number_with_precision('12.3', :precision => 0, :significant => true )).to eq('12')
+    expect(number_with_precision(123.987, precision: 0, significant: true)).to eq('124')
+    expect(number_with_precision(12, precision: 0, significant: true)).to eq('12')
+    expect(number_with_precision('12.3', precision: 0, significant: true)).to eq('12')
   end
 
-  it 'should number_to_human_size' do
+  it 'number_to_human_sizes' do
     expect(number_to_human_size(0)).to eq('0 Bytes')
     expect(number_to_human_size(1)).to eq('1 Byte')
     expect(number_to_human_size(3.14159265)).to eq('3 Bytes')
     expect(number_to_human_size(123.0)).to eq('123 Bytes')
     expect(number_to_human_size(123)).to eq('123 Bytes')
     expect(number_to_human_size(1234)).to eq('1.21 KB')
-    expect(number_to_human_size(12345)).to eq('12.1 KB')
-    expect(number_to_human_size(1234567)).to eq('1.18 MB')
-    expect(number_to_human_size(1234567890)).to eq('1.15 GB')
-    expect(number_to_human_size(1234567890123)).to eq('1.12 TB')
+    expect(number_to_human_size(12_345)).to eq('12.1 KB')
+    expect(number_to_human_size(1_234_567)).to eq('1.18 MB')
+    expect(number_to_human_size(1_234_567_890)).to eq('1.15 GB')
+    expect(number_to_human_size(1_234_567_890_123)).to eq('1.12 TB')
     expect(number_to_human_size(terabytes(1026))).to eq('1030 TB')
     expect(number_to_human_size(kilobytes(444))).to eq('444 KB')
     expect(number_to_human_size(megabytes(1023))).to eq('1020 MB')
     expect(number_to_human_size(terabytes(3))).to eq('3 TB')
-    expect(number_to_human_size(1234567, :precision => 2)).to eq('1.2 MB')
-    expect(number_to_human_size(3.14159265, :precision => 4)).to eq('3 Bytes')
+    expect(number_to_human_size(1_234_567, precision: 2)).to eq('1.2 MB')
+    expect(number_to_human_size(3.14159265, precision: 4)).to eq('3 Bytes')
     expect(number_to_human_size('123')).to eq('123 Bytes')
-    expect(number_to_human_size(kilobytes(1.0123), :precision => 2)).to eq('1 KB')
-    expect(number_to_human_size(kilobytes(1.0100), :precision => 4)).to eq('1.01 KB')
-    expect(number_to_human_size(kilobytes(10.000), :precision => 4)).to eq('10 KB')
+    expect(number_to_human_size(kilobytes(1.0123), precision: 2)).to eq('1 KB')
+    expect(number_to_human_size(kilobytes(1.0100), precision: 4)).to eq('1.01 KB')
+    expect(number_to_human_size(kilobytes(10.000), precision: 4)).to eq('10 KB')
     expect(number_to_human_size(1.1)).to eq('1 Byte')
     expect(number_to_human_size(10)).to eq('10 Bytes')
   end
 
-  it 'should number_to_human_size_with_options_hash' do
-    expect(number_to_human_size(1234567, :precision => 2)).to eq('1.2 MB')
-    expect(number_to_human_size(3.14159265, :precision => 4)).to eq('3 Bytes')
-    expect(number_to_human_size(kilobytes(1.0123), :precision => 2)).to eq('1 KB')
-    expect(number_to_human_size(kilobytes(1.0100), :precision => 4)).to eq('1.01 KB')
-    expect(number_to_human_size(kilobytes(10.000), :precision => 4)).to eq('10 KB')
-    expect(number_to_human_size(1234567890123, :precision => 1)).to eq('1 TB')
-    expect(number_to_human_size(524288000, :precision=>3)).to eq('500 MB')
-    expect(number_to_human_size(9961472, :precision=>0)).to eq('10 MB')
-    expect(number_to_human_size(41010, :precision => 1)).to eq('40 KB')
-    expect(number_to_human_size(41100, :precision => 2)).to eq('40 KB')
-    expect(number_to_human_size(kilobytes(1.0123), :precision => 2, :strip_insignificant_zeros => false)).to eq('1.0 KB')
-    expect(number_to_human_size(kilobytes(1.0123), :precision => 3, :significant => false)).to eq('1.012 KB')
-    number_to_human_size(kilobytes(1.0123), :precision => 0, :significant => true) #ignores significant it precision is 0.should == '1 KB'
+  it 'number_to_human_size_with_options_hashes' do
+    expect(number_to_human_size(1_234_567, precision: 2)).to eq('1.2 MB')
+    expect(number_to_human_size(3.14159265, precision: 4)).to eq('3 Bytes')
+    expect(number_to_human_size(kilobytes(1.0123), precision: 2)).to eq('1 KB')
+    expect(number_to_human_size(kilobytes(1.0100), precision: 4)).to eq('1.01 KB')
+    expect(number_to_human_size(kilobytes(10.000), precision: 4)).to eq('10 KB')
+    expect(number_to_human_size(1_234_567_890_123, precision: 1)).to eq('1 TB')
+    expect(number_to_human_size(524_288_000, precision: 3)).to eq('500 MB')
+    expect(number_to_human_size(9_961_472, precision: 0)).to eq('10 MB')
+    expect(number_to_human_size(41_010, precision: 1)).to eq('40 KB')
+    expect(number_to_human_size(41_100, precision: 2)).to eq('40 KB')
+    expect(number_to_human_size(kilobytes(1.0123), precision: 2,
+                                                   strip_insignificant_zeros: false)).to eq('1.0 KB')
+    expect(number_to_human_size(kilobytes(1.0123), precision: 3, significant: false)).to eq('1.012 KB')
+    # significant is ignored when precision is 0
+    expect(number_to_human_size(kilobytes(1.0123), precision: 0, significant: true)).to eq('1 KB')
   end
 
-  it 'should number_to_human_size_with_custom_delimiter_and_separator' do
-   expect(number_to_human_size(kilobytes(1.0123), :precision => 3, :separator => ','))                    .to eq('1,01 KB')
-   expect(number_to_human_size(kilobytes(1.0100), :precision => 4, :separator => ','))                    .to eq('1,01 KB')
-   expect(number_to_human_size(terabytes(1000.1), :precision => 5, :delimiter => '.', :separator => ',')) .to eq('1.000,1 TB')
+  it 'number_to_human_size_with_custom_delimiter_and_separators' do
+    expect(number_to_human_size(kilobytes(1.0123), precision: 3,
+                                                   separator: ',')).to eq('1,01 KB')
+    expect(number_to_human_size(kilobytes(1.0100), precision: 4,
+                                                   separator: ',')).to eq('1,01 KB')
+    expect(number_to_human_size(terabytes(1000.1), precision: 5, delimiter: '.',
+                                                   separator: ',')).to eq('1.000,1 TB')
   end
 
-  it 'should number_helpers_should_return_nil_when_given_nil' do
+  it 'number_helpers_should_return_nil_when_given_nils' do
     expect(number_with_delimiter(nil)).to be_nil
     expect(number_with_precision(nil)).to be_nil
     expect(number_to_human_size(nil)).to be_nil
   end
 
-  it 'should number_helpers_should_return_non_numeric_param_unchanged' do
+  it 'number_helpers_should_return_non_numeric_param_unchangeds' do
     expect(number_with_delimiter('x')).to eq('x')
     expect(number_with_precision('x.')).to eq('x.')
     expect(number_with_precision('x')).to eq('x')
     expect(number_to_human_size('x')).to eq('x')
   end
 
-  it 'should number_helpers_should_raise_error_if_invalid_when_specified' do
+  it 'number_helpers_should_raise_error_if_invalid_when_specifieds' do
     expect do
-      number_to_human_size('x', :raise => true)
+      number_to_human_size('x', raise: true)
     end.to raise_error(SitemapGenerator::Helpers::NumberHelper::InvalidNumberError)
     begin
-      number_to_human_size('x', :raise => true)
+      number_to_human_size('x', raise: true)
     rescue SitemapGenerator::Helpers::NumberHelper::InvalidNumberError => e
       expect(e.number).to eq('x')
     end
 
     expect do
-      number_with_precision('x', :raise => true)
+      number_with_precision('x', raise: true)
     end.to raise_error(SitemapGenerator::Helpers::NumberHelper::InvalidNumberError)
     begin
-      number_with_precision('x', :raise => true)
+      number_with_precision('x', raise: true)
     rescue SitemapGenerator::Helpers::NumberHelper::InvalidNumberError => e
       expect(e.number).to eq('x')
     end
 
     expect do
-      number_with_delimiter('x', :raise => true)
+      number_with_delimiter('x', raise: true)
     end.to raise_error(SitemapGenerator::Helpers::NumberHelper::InvalidNumberError)
     begin
-      number_with_delimiter('x', :raise => true)
+      number_with_delimiter('x', raise: true)
     rescue SitemapGenerator::Helpers::NumberHelper::InvalidNumberError => e
       expect(e.number).to eq('x')
     end

--- a/spec/sitemap_generator/interpreter_spec.rb
+++ b/spec/sitemap_generator/interpreter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'sitemap_generator/interpreter'
 
@@ -5,7 +7,7 @@ RSpec.describe SitemapGenerator::Interpreter do
   include SitemapHelpers
 
   let(:link_set)    { SitemapGenerator::LinkSet.new }
-  let(:interpreter) { SitemapGenerator::Interpreter.new(:link_set => link_set) }
+  let(:interpreter) { described_class.new(link_set: link_set) }
 
   before :all do
     SitemapGenerator::Sitemap.reset!
@@ -21,52 +23,52 @@ RSpec.describe SitemapGenerator::Interpreter do
     delete_sitemap_file_from_rails_app
   end
 
-  it 'should find the config file if Rails.root doesn\'t end in a slash' do
-    stub_const('Rails', double('Rails', :root => SitemapGenerator.app.root.to_s.sub(/\/$/, '')))
-    expect { SitemapGenerator::Interpreter.run }.not_to raise_error
+  it "finds the config file if Rails.root doesn't end in a slash" do
+    stub_const('Rails', double('Rails', root: SitemapGenerator.app.root.to_s.sub(%r{/$}, '')))
+    expect { described_class.run }.not_to raise_error
   end
 
-  it 'should set the verbose option' do
-    expect_any_instance_of(SitemapGenerator::Interpreter).to receive(:instance_eval)
-    interpreter = SitemapGenerator::Interpreter.run(:verbose => true)
+  it 'sets the verbose option' do
+    expect_any_instance_of(described_class).to receive(:instance_eval)
+    interpreter = described_class.run(verbose: true)
     expect(interpreter.instance_variable_get(:@linkset).verbose).to be(true)
   end
 
   describe 'link_set' do
-    it 'should default to the default LinkSet' do
-      expect(SitemapGenerator::Interpreter.new.sitemap).to be(SitemapGenerator::Sitemap)
+    it 'defaults to the default LinkSet' do
+      expect(described_class.new.sitemap).to be(SitemapGenerator::Sitemap)
     end
 
-    it 'should allow setting the LinkSet as an option' do
+    it 'allows setting the LinkSet as an option' do
       expect(interpreter.sitemap).to be(link_set)
     end
   end
 
   describe 'public interface' do
     describe 'add' do
-      it 'should add a link to the sitemap' do
-        expect(link_set).to receive(:add).with('test', { :option => 'value' })
-        interpreter.add('test', :option => 'value')
+      it 'adds a link to the sitemap' do
+        expect(link_set).to receive(:add).with('test', { option: 'value' })
+        interpreter.add('test', option: 'value')
       end
     end
 
     describe 'group' do
-      it 'should start a new group' do
-        expect(link_set).to receive(:group).with('test', { :option => 'value' })
-        interpreter.group('test', :option => 'value')
+      it 'starts a new group' do
+        expect(link_set).to receive(:group).with('test', { option: 'value' })
+        interpreter.group('test', option: 'value')
       end
     end
 
     describe 'sitemap' do
-      it 'should return the LinkSet' do
+      it 'returns the LinkSet' do
         expect(interpreter.sitemap).to be(link_set)
       end
     end
 
     describe 'add_to_index' do
-      it 'should add a link to the sitemap index' do
-        expect(link_set).to receive(:add_to_index).with('test', { :option => 'value' })
-        interpreter.add_to_index('test', :option => 'value')
+      it 'adds a link to the sitemap index' do
+        expect(link_set).to receive(:add_to_index).with('test', { option: 'value' })
+        interpreter.add_to_index('test', option: 'value')
       end
     end
   end
@@ -104,26 +106,28 @@ RSpec.describe SitemapGenerator::Interpreter do
   end
 
   describe 'eval' do
-    it 'should yield the LinkSet to the block' do
-      interpreter.eval(:yield_sitemap => true) do |sitemap|
+    it 'yields the LinkSet to the block' do
+      interpreter.eval(yield_sitemap: true) do |sitemap|
         expect(sitemap).to be(link_set)
       end
     end
 
-    it 'should not yield the LinkSet to the block' do
+    # rubocop:disable RSpec/NoExpectationExample -- explicit receiver (this.expect), cop only recognizes bare expect()
+    it 'does not yield the LinkSet to the block' do
       # Assign self to a local variable so it is captured by the block
       this = self
-      interpreter.eval(:yield_sitemap => false) do
+      interpreter.eval(yield_sitemap: false) do
         this.expect(self).to this.be(this.interpreter)
       end
     end
 
-    it 'should not yield the LinkSet to the block by default' do
+    it 'does not yield the LinkSet to the block by default' do
       # Assign self to a local variable so it is captured by the block
       this = self
       interpreter.eval do
         this.expect(self).to this.be(this.interpreter)
       end
     end
+    # rubocop:enable RSpec/NoExpectationExample
   end
 end

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe SitemapGenerator::LinkSet do
 
     it 'does not modify the index when the filename changes' do
       @ls.filename = :newname
-      expect(@ls.sitemap.location.filename).to match(/newname/)
+      expect(@ls.sitemap.location.filename).to include('newname')
       @ls.sitemap_index.location.filename.include?('sitemap')
     end
 
@@ -320,7 +320,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       it 'sets the value' do
         group = ls.group(filename: :xxx)
         expect(group.filename).to eq(:xxx)
-        expect(group.sitemap.location.filename).to match(/xxx/)
+        expect(group.sitemap.location.filename).to include('xxx')
       end
     end
 
@@ -392,7 +392,7 @@ RSpec.describe SitemapGenerator::LinkSet do
         group = ls.group(namer: namer)
         expect(group.namer).to eq(namer)
         expect(group.sitemap.location.namer).to eq(namer)
-        expect(group.sitemap.location.filename).to match(/xxx/)
+        expect(group.sitemap.location.filename).to include('xxx')
       end
     end
 
@@ -499,7 +499,7 @@ RSpec.describe SitemapGenerator::LinkSet do
     it 'sets the filename' do
       ls.create(filename: :xxx)
       expect(ls.filename).to eq(:xxx)
-      expect(ls.sitemap.location.filename).to match(/xxx/)
+      expect(ls.sitemap.location.filename).to include('xxx')
     end
 
     it 'sets verbose' do
@@ -533,7 +533,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls.create(namer: namer)
       expect(ls.namer).to eq(namer)
       expect(ls.sitemap.location.namer).to eq(namer)
-      expect(ls.sitemap.location.filename).to match(/xxx/)
+      expect(ls.sitemap.location.filename).to include('xxx')
     end
 
     it 'supports both namer and filename options' do

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -1,70 +1,73 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'uri'
 
 RSpec.describe SitemapGenerator::LinkSet do
   let(:default_host) { 'http://example.com' }
-  let(:ls)           { SitemapGenerator::LinkSet.new(:default_host => default_host) }
+  let(:ls)           { described_class.new(default_host: default_host) }
 
   describe 'initializer options' do
-    options = [:public_path, :sitemaps_path, :default_host, :filename, :search_engines, :max_sitemap_links]
-    values = [File.expand_path(SitemapGenerator.app.root + 'tmp/'), 'mobile/', 'http://myhost.com', :xxx, { :abc => '123' }, 10]
+    options = %i[public_path sitemaps_path default_host filename search_engines max_sitemap_links]
+    values = [File.expand_path("#{SitemapGenerator.app.root}/tmp/"), 'mobile/', 'http://myhost.com', :xxx,
+              { abc: '123' }, 10]
 
     options.zip(values).each do |option, value|
-      it 'should set #{option} to #{value}' do
-        ls = SitemapGenerator::LinkSet.new(option => value)
+      it "sets #{option} to #{value}" do
+        ls = described_class.new(option => value)
         expect(ls.send(option)).to eq(value)
       end
     end
   end
 
   describe 'default options' do
-    let(:ls) { SitemapGenerator::LinkSet.new }
+    let(:ls) { described_class.new }
 
     default_options = {
-      :filename      => :sitemap,
-      :sitemaps_path => nil,
-      :public_path   => SitemapGenerator.app.root + 'public/',
-      :default_host  => nil,
-      :include_index => false,
-      :include_root  => true,
-      :create_index  => :auto,
-      :max_sitemap_links => SitemapGenerator::MAX_SITEMAP_LINKS
+      filename: :sitemap,
+      sitemaps_path: nil,
+      public_path: Pathname.new("#{SitemapGenerator.app.root}/public/"),
+      default_host: nil,
+      include_index: false,
+      include_root: true,
+      create_index: :auto,
+      max_sitemap_links: SitemapGenerator::MAX_SITEMAP_LINKS
     }
 
     default_options.each do |option, value|
-      it '#{option} should default to #{value}' do
+      it "#{option} should default to #{value}" do
         expect(ls.send(option)).to eq(value)
       end
     end
   end
 
   describe 'include_root include_index option' do
-    it 'should include the root url and the sitemap index url' do
-      ls = SitemapGenerator::LinkSet.new(:default_host => default_host, :include_root => true, :include_index => true)
+    it 'includes the root url and the sitemap index url' do
+      ls = described_class.new(default_host: default_host, include_root: true, include_index: true)
       expect(ls.include_root).to be(true)
       expect(ls.include_index).to be(true)
       ls.create { |sitemap| }
       expect(ls.sitemap.link_count).to eq(2)
     end
 
-    it 'should not include the root url' do
-      ls = SitemapGenerator::LinkSet.new(:default_host => default_host, :include_root => false)
+    it 'does not include the root url' do
+      ls = described_class.new(default_host: default_host, include_root: false)
       expect(ls.include_root).to be(false)
       expect(ls.include_index).to be(false)
       ls.create { |sitemap| }
       expect(ls.sitemap.link_count).to eq(0)
     end
 
-    it 'should not include the sitemap index url' do
-      ls = SitemapGenerator::LinkSet.new(:default_host => default_host, :include_index => false)
+    it 'does not include the sitemap index url' do
+      ls = described_class.new(default_host: default_host, include_index: false)
       expect(ls.include_root).to be(true)
       expect(ls.include_index).to be(false)
       ls.create { |sitemap| }
       expect(ls.sitemap.link_count).to eq(1)
     end
 
-    it 'should not include the root url or the sitemap index url' do
-      ls = SitemapGenerator::LinkSet.new(:default_host => default_host, :include_root => false, :include_index => false)
+    it 'does not include the root url or the sitemap index url' do
+      ls = described_class.new(default_host: default_host, include_root: false, include_index: false)
       expect(ls.include_root).to be(false)
       expect(ls.include_index).to be(false)
       ls.create { |sitemap| }
@@ -73,23 +76,23 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'sitemaps public_path' do
-    it 'should default to public/' do
-      path = SitemapGenerator.app.root + 'public/'
+    it 'defaults to public/' do
+      path = Pathname.new("#{SitemapGenerator.app.root}/public/")
       expect(ls.public_path).to eq(path)
       expect(ls.sitemap.location.public_path).to eq(path)
       expect(ls.sitemap_index.location.public_path).to eq(path)
     end
 
-    it 'should change when the public_path is changed' do
-      path = SitemapGenerator.app.root + 'tmp/'
+    it 'changes when the public_path is changed' do
+      path = Pathname.new("#{SitemapGenerator.app.root}/tmp/")
       ls.public_path = 'tmp/'
       expect(ls.public_path).to eq(path)
       expect(ls.sitemap.location.public_path).to eq(path)
       expect(ls.sitemap_index.location.public_path).to eq(path)
     end
 
-    it 'should append a slash to the path' do
-      path = SitemapGenerator.app.root + 'tmp/'
+    it 'appends a slash to the path' do
+      path = Pathname.new("#{SitemapGenerator.app.root}/tmp/")
       ls.public_path = 'tmp'
       expect(ls.public_path).to eq(path)
       expect(ls.sitemap.location.public_path).to eq(path)
@@ -98,21 +101,21 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'sitemaps url' do
-    it 'should change when the default_host is changed' do
+    it 'changes when the default_host is changed' do
       ls.default_host = 'http://one.com'
       expect(ls.default_host).to eq('http://one.com')
       expect(ls.default_host).to eq(ls.sitemap.location.host)
       expect(ls.default_host).to eq(ls.sitemap_index.location.host)
     end
 
-    it 'should change when the sitemaps_path is changed' do
+    it 'changes when the sitemaps_path is changed' do
       ls.default_host = 'http://one.com'
       ls.sitemaps_path = 'sitemaps/'
       expect(ls.sitemap.location.url).to eq('http://one.com/sitemaps/sitemap.xml.gz')
       expect(ls.sitemap_index.location.url).to eq('http://one.com/sitemaps/sitemap.xml.gz')
     end
 
-    it 'should append a slash to the path' do
+    it 'appends a slash to the path' do
       ls.default_host = 'http://one.com'
       ls.sitemaps_path = 'sitemaps'
       expect(ls.sitemap.location.url).to eq('http://one.com/sitemaps/sitemap.xml.gz')
@@ -121,7 +124,7 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'sitemap_index_url' do
-    it 'should return the url to the index file' do
+    it 'returns the url to the index file' do
       ls.default_host = default_host
       expect(ls.sitemap_index.location.url).to eq("#{default_host}/sitemap.xml.gz")
       expect(ls.sitemap_index_url).to eq(ls.sitemap_index.location.url)
@@ -129,18 +132,18 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'search_engines' do
-    it 'should have search engines by default' do
+    it 'has search engines by default' do
       expect(ls.search_engines).to be_a(Hash)
       expect(ls.search_engines.size).to eq(0)
     end
 
-    it 'should support being modified' do
+    it 'supports being modified' do
       ls.search_engines[:newengine] = 'abc'
       expect(ls.search_engines.size).to eq(1)
     end
 
-    it 'should support being set to nil' do
-      ls = SitemapGenerator::LinkSet.new(:default_host => 'http://one.com', :search_engines => nil)
+    it 'supports being set to nil' do
+      ls = described_class.new(default_host: 'http://one.com', search_engines: nil)
       expect(ls.search_engines).to be_a(Hash)
       expect(ls.search_engines).to be_empty
       ls.search_engines = nil
@@ -150,68 +153,71 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'ping search engines' do
-    it 'should raise if no host is set' do
-      expect { SitemapGenerator::LinkSet.new.ping_search_engines }.to raise_error(SitemapGenerator::SitemapError, 'No value set for host')
+    it 'raises if no host is set' do
+      expect do
+        described_class.new.ping_search_engines
+      end.to raise_error(SitemapGenerator::SitemapError, 'No value set for host')
     end
 
-    it 'should use the sitemap index url provided' do
+    it 'uses the sitemap index url provided' do
       index_url = 'http://example.com/index.xml'
-      ls = SitemapGenerator::LinkSet.new(:search_engines => { :google => 'http://google.com/?url=%s' })
+      ls = described_class.new(search_engines: { google: 'http://google.com/?url=%s' })
       request = stub_request(:get, "http://google.com/?url=#{URI.encode_www_form_component(index_url)}")
       ls.ping_search_engines(index_url)
       expect(request).to have_been_requested
     end
 
-    it 'should use the sitemap index url from the link set' do
-      ls = SitemapGenerator::LinkSet.new(
-        :default_host => default_host,
-        :search_engines => { :google => 'http://google.com/?url=%s' })
+    it 'uses the sitemap index url from the link set' do
+      ls = described_class.new(
+        default_host: default_host,
+        search_engines: { google: 'http://google.com/?url=%s' }
+      )
       index_url = ls.sitemap_index_url
       request = stub_request(:get, "http://google.com/?url=#{URI.encode_www_form_component(index_url)}")
       ls.ping_search_engines
       expect(request).to have_been_requested
     end
 
-    it 'should include the given search engines' do
+    it 'includes the given search engines' do
       ls.search_engines = nil
-      request = stub_request(:get, /^http:\/\/newnegine\.com\?/)
-      ls.ping_search_engines(:newengine => 'http://newnegine.com?%s')
+      request = stub_request(:get, %r{^http://newnegine\.com\?})
+      ls.ping_search_engines(newengine: 'http://newnegine.com?%s')
       expect(request).to have_been_requested
 
       WebMock.reset_executed_requests!
-      ls.ping_search_engines(:newengine => 'http://newnegine.com?%s', :anotherengine => 'http://newnegine.com?%s')
+      ls.ping_search_engines(newengine: 'http://newnegine.com?%s', anotherengine: 'http://newnegine.com?%s')
       expect(request).to have_been_requested.twice
     end
   end
 
   describe 'verbose' do
-    it 'should be set as an initialize option' do
-      expect(SitemapGenerator::LinkSet.new(:default_host => default_host, :verbose => false).verbose).to be(false)
-      expect(SitemapGenerator::LinkSet.new(:default_host => default_host, :verbose => true).verbose).to be(true)
+    it 'is set as an initialize option' do
+      expect(described_class.new(default_host: default_host, verbose: false).verbose).to be(false)
+      expect(described_class.new(default_host: default_host, verbose: true).verbose).to be(true)
     end
 
-    it 'should be set as an accessor' do
+    it 'is set as an accessor' do
       ls.verbose = true
       expect(ls.verbose).to be(true)
       ls.verbose = false
       expect(ls.verbose).to be(false)
     end
 
-    it 'should use SitemapGenerator.verbose as a default' do
+    it 'uses SitemapGenerator.verbose as a default when true' do
       expect(SitemapGenerator).to receive(:verbose).and_return(true).twice
-      expect(SitemapGenerator::LinkSet.new.verbose).to be(true)
+      expect(described_class.new.verbose).to be(true)
     end
 
-    it 'should use SitemapGenerator.verbose as a default' do
+    it 'uses SitemapGenerator.verbose as a default when false' do
       expect(SitemapGenerator).to receive(:verbose).and_return(false).twice
-      expect(SitemapGenerator::LinkSet.new.verbose).to be(false)
+      expect(described_class.new.verbose).to be(false)
     end
   end
 
   describe 'when finalizing' do
-    let(:ls) { SitemapGenerator::LinkSet.new(:default_host => default_host, :verbose => true, :create_index => true) }
+    let(:ls) { described_class.new(default_host: default_host, verbose: true, create_index: true) }
 
-    it 'should output summary lines' do
+    it 'outputs summary lines' do
       expect(ls.sitemap.location).to receive(:summary)
       expect(ls.sitemap_index.location).to receive(:summary)
       ls.finalize!
@@ -221,23 +227,23 @@ RSpec.describe SitemapGenerator::LinkSet do
   describe 'sitemaps host' do
     let(:new_host) { 'http://wowza.com' }
 
-    it 'should have a host' do
+    it 'has a host' do
       ls.default_host = default_host
       expect(ls.default_host).to eq(default_host)
     end
 
-    it 'should default to default host' do
+    it 'defaults to default host' do
       expect(ls.sitemaps_host).to eq(ls.default_host)
     end
 
-    it 'should update the host in the sitemaps when changed' do
+    it 'updates the host in the sitemaps when changed' do
       ls.sitemaps_host = new_host
       expect(ls.sitemaps_host).to eq(new_host)
       expect(ls.sitemap.location.host).to eq(ls.sitemaps_host)
       expect(ls.sitemap_index.location.host).to eq(ls.sitemaps_host)
     end
 
-    it 'should not change the default host for links' do
+    it 'does not change the default host for links' do
       ls.sitemaps_host = new_host
       expect(ls.default_host).to eq(default_host)
     end
@@ -245,23 +251,23 @@ RSpec.describe SitemapGenerator::LinkSet do
 
   describe 'with a sitemap index specified' do
     before do
-      @index = SitemapGenerator::Builder::SitemapIndexFile.new(:host => default_host)
-      @ls = SitemapGenerator::LinkSet.new(:sitemap_index => @index, :sitemaps_host => 'http://newhost.com')
+      @index = SitemapGenerator::Builder::SitemapIndexFile.new(host: default_host)
+      @ls = described_class.new(sitemap_index: @index, sitemaps_host: 'http://newhost.com')
     end
 
-    it 'should not modify the index' do
+    it 'does not modify the index when the filename changes' do
       @ls.filename = :newname
       expect(@ls.sitemap.location.filename).to match(/newname/)
-      @ls.sitemap_index.location.filename =~ /sitemap/
+      @ls.sitemap_index.location.filename.include?('sitemap')
     end
 
-    it 'should not modify the index' do
+    it 'does not modify the index when sitemaps_host changes' do
       @ls.sitemaps_host = 'http://newhost.com'
       expect(@ls.sitemap.location.host).to eq('http://newhost.com')
       expect(@ls.sitemap_index.location.host).to eq(default_host)
     end
 
-    it 'should not finalize the index' do
+    it 'does not finalize the index' do
       @ls.send(:finalize_sitemap_index!)
       expect(@ls.sitemap_index.finalized?).to be(false)
     end
@@ -269,121 +275,121 @@ RSpec.describe SitemapGenerator::LinkSet do
 
   describe 'new group' do
     describe 'general behaviour' do
-      it 'should return a LinkSet' do
-        expect(ls.group).to be_a(SitemapGenerator::LinkSet)
+      it 'returns a LinkSet' do
+        expect(ls.group).to be_a(described_class)
       end
 
-      it 'should inherit the index' do
+      it 'inherits the index' do
         expect(ls.group.sitemap_index).to eq(ls.sitemap_index)
       end
 
-      it 'should protect the sitemap_index' do
+      it 'protects the sitemap_index' do
         expect(ls.group.instance_variable_get(:@protect_index)).to be(true)
       end
 
-      it 'should not allow chaning the public_path' do
-        expect(ls.group(:public_path => 'new/path/').public_path.to_s).to eq(ls.public_path.to_s)
+      it 'does not allow chaning the public_path' do
+        expect(ls.group(public_path: 'new/path/').public_path.to_s).to eq(ls.public_path.to_s)
       end
     end
 
     describe 'include_index' do
-      it 'should set the value' do
-        expect(ls.group(:include_index => !ls.include_index).include_index).not_to eq(ls.include_index)
+      it 'sets the value' do
+        expect(ls.group(include_index: !ls.include_index).include_index).not_to eq(ls.include_index)
       end
 
-      it 'should default to false' do
+      it 'defaults to false' do
         expect(ls.group.include_index).to be(false)
       end
     end
 
     describe 'include_root' do
-      it 'should set the value' do
-        expect(ls.group(:include_root => !ls.include_root).include_root).not_to eq(ls.include_root)
+      it 'sets the value' do
+        expect(ls.group(include_root: !ls.include_root).include_root).not_to eq(ls.include_root)
       end
 
-      it 'should default to false' do
+      it 'defaults to false' do
         expect(ls.group.include_root).to be(false)
       end
     end
 
     describe 'filename' do
-      it 'should inherit the value' do
+      it 'inherits the value' do
         expect(ls.group.filename).to eq(:sitemap)
       end
 
-      it 'should set the value' do
-        group = ls.group(:filename => :xxx)
+      it 'sets the value' do
+        group = ls.group(filename: :xxx)
         expect(group.filename).to eq(:xxx)
         expect(group.sitemap.location.filename).to match(/xxx/)
       end
     end
 
     describe 'verbose' do
-      it 'should inherit the value' do
+      it 'inherits the value' do
         expect(ls.group.verbose).to eq(ls.verbose)
       end
 
-      it 'should set the value' do
-        expect(ls.group(:verbose => !ls.verbose).verbose).not_to eq(ls.verbose)
+      it 'sets the value' do
+        expect(ls.group(verbose: !ls.verbose).verbose).not_to eq(ls.verbose)
       end
     end
 
     describe 'sitemaps_path' do
-      it 'should inherit the sitemaps_path' do
+      it 'inherits the sitemaps_path' do
         group = ls.group
         expect(group.sitemaps_path).to eq(ls.sitemaps_path)
         expect(group.sitemap.location.sitemaps_path).to eq(ls.sitemap.location.sitemaps_path)
       end
 
-      it 'should set the sitemaps_path' do
+      it 'sets the sitemaps_path' do
         path = 'new/path'
-        group = ls.group(:sitemaps_path => path)
+        group = ls.group(sitemaps_path: path)
         expect(group.sitemaps_path).to eq(path)
         expect(group.sitemap.location.sitemaps_path.to_s).to eq('new/path/')
       end
     end
 
     describe 'default_host' do
-      it 'should inherit the default_host' do
+      it 'inherits the default_host' do
         expect(ls.group.default_host).to eq(default_host)
       end
 
-      it 'should set the default_host' do
+      it 'sets the default_host' do
         host = 'http://defaulthost.com'
-        group = ls.group(:default_host => host)
+        group = ls.group(default_host: host)
         expect(group.default_host).to eq(host)
         expect(group.sitemap.location.host).to eq(host)
       end
     end
 
     describe 'sitemaps_host' do
-      it 'should set the sitemaps host' do
+      it 'sets the sitemaps host' do
         @host = 'http://sitemaphost.com'
-        @group = ls.group(:sitemaps_host => @host)
+        @group = ls.group(sitemaps_host: @host)
         expect(@group.sitemaps_host).to eq(@host)
         expect(@group.sitemap.location.host).to eq(@host)
       end
 
-      it 'should finalize the sitemap if it is the only option' do
+      it 'finalizes the sitemap if it is the only option' do
         expect(ls).to receive(:finalize_sitemap!)
-        ls.group(:sitemaps_host => 'http://test.com') {}
+        ls.group(sitemaps_host: 'http://test.com') {}
       end
 
-      it 'should use the same namer' do
-        @group = ls.group(:sitemaps_host => 'http://test.com') {}
+      it 'uses the same namer' do
+        @group = ls.group(sitemaps_host: 'http://test.com') {}
         expect(@group.sitemap.location.namer).to eq(ls.sitemap.location.namer)
       end
     end
 
     describe 'namer' do
-      it 'should inherit the value' do
+      it 'inherits the value' do
         expect(ls.group.namer).to eq(ls.namer)
         expect(ls.group.sitemap.location.namer).to eq(ls.namer)
       end
 
-      it 'should set the value' do
+      it 'sets the value' do
         namer = SitemapGenerator::SimpleNamer.new(:xxx)
-        group = ls.group(:namer => namer)
+        group = ls.group(namer: namer)
         expect(group.namer).to eq(namer)
         expect(group.sitemap.location.namer).to eq(namer)
         expect(group.sitemap.location.filename).to match(/xxx/)
@@ -391,21 +397,21 @@ RSpec.describe SitemapGenerator::LinkSet do
     end
 
     describe 'create_index' do
-      it 'should inherit the value' do
+      it 'inherits the value' do
         expect(ls.group.create_index).to eq(ls.create_index)
         ls.create_index = :some_value
         expect(ls.group.create_index).to eq(:some_value)
       end
 
-      it 'should set the value' do
-        group = ls.group(:create_index => :some_value)
+      it 'sets the value' do
+        group = ls.group(create_index: :some_value)
         expect(group.create_index).to eq(:some_value)
       end
     end
 
     describe 'should share the current sitemap' do
       it 'if only default_host is passed' do
-        group = ls.group(:default_host => 'http://newhost.com')
+        group = ls.group(default_host: 'http://newhost.com')
         expect(group.sitemap).to eq(ls.sitemap)
         expect(group.sitemap.location.host).to eq('http://newhost.com')
       end
@@ -413,68 +419,66 @@ RSpec.describe SitemapGenerator::LinkSet do
 
     describe 'should not share the current sitemap' do
       {
-        :filename => :xxx,
-        :sitemaps_path => 'en/',
-        :namer => SitemapGenerator::SimpleNamer.new(:sitemap)
+        filename: :xxx,
+        sitemaps_path: 'en/',
+        namer: SitemapGenerator::SimpleNamer.new(:sitemap)
       }.each do |key, value|
-        it 'if #{key} is present' do
+        it "if #{key} is present" do
           expect(ls.group(key => value).sitemap).not_to eq(ls.sitemap)
         end
       end
     end
 
     describe 'finalizing' do
-      it 'should only finalize the sitemaps if a block is passed' do
+      it 'only finalizes the sitemaps if a block is passed' do
         @group = ls.group
         expect(@group.sitemap.finalized?).to be(false)
       end
 
-      it 'should not finalize the sitemap if a group is created' do
+      it 'does not finalize the sitemap if a group is created' do
         ls.create { group {} }
         expect(ls.sitemap.empty?).to be(true)
         expect(ls.sitemap.finalized?).to be(false)
       end
 
-      {:sitemaps_path => 'en/',
-        :filename => :example,
-        :namer => SitemapGenerator::SimpleNamer.new(:sitemap)
-      }.each do |k, v|
-
-        it 'should not finalize the sitemap if #{k} is present' do
-          expect(ls).to receive(:finalize_sitemap!).never
-          ls.group(k => v) { }
+      { sitemaps_path: 'en/',
+        filename: :example,
+        namer: SitemapGenerator::SimpleNamer.new(:sitemap) }.each do |k, v|
+        it "does not finalize the sitemap if #{k} is present" do
+          expect(ls).not_to receive(:finalize_sitemap!)
+          ls.group(k => v) {}
         end
       end
     end
 
     describe 'adapter' do
-      it 'should inherit the current adapter' do
+      it 'inherits the current adapter' do
         ls.adapter = Object.new
         group = ls.group
         expect(group).not_to be(ls)
         expect(group.adapter).to be(ls.adapter)
       end
 
-      it 'should set the value' do
+      it 'sets the value' do
         adapter = Object.new
-        group = ls.group(:adapter => adapter)
+        group = ls.group(adapter: adapter)
         expect(group.adapter).to be(adapter)
       end
     end
   end
 
   describe 'after create' do
-    it 'should finalize the sitemap index' do
+    it 'finalizes the sitemap index' do
       ls.create {}
       expect(ls.sitemap_index.finalized?).to be(true)
     end
 
-    it 'should finalize the sitemap' do
+    it 'finalizes the sitemap' do
       ls.create {}
       expect(ls.sitemap.finalized?).to be(true)
     end
 
-    it 'should not finalize the sitemap if a group was created' do
+    it 'does not finalize the sitemap if a group was created' do
       ls.instance_variable_set(:@created_group, true)
       ls.send(:finalize_sitemap!)
       expect(ls.sitemap.finalized?).to be(false)
@@ -482,93 +486,93 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'options to create' do
-    it 'should set include_index' do
+    it 'sets include_index' do
       original = ls.include_index
-      expect(ls.create(:include_index => !original).include_index).not_to eq(original)
+      expect(ls.create(include_index: !original).include_index).not_to eq(original)
     end
 
-    it 'should set include_root' do
+    it 'sets include_root' do
       original = ls.include_root
-      expect(ls.create(:include_root => !original).include_root).not_to eq(original)
+      expect(ls.create(include_root: !original).include_root).not_to eq(original)
     end
 
-    it 'should set the filename' do
-      ls.create(:filename => :xxx)
+    it 'sets the filename' do
+      ls.create(filename: :xxx)
       expect(ls.filename).to eq(:xxx)
       expect(ls.sitemap.location.filename).to match(/xxx/)
     end
 
-    it 'should set verbose' do
+    it 'sets verbose' do
       original = ls.verbose
-      expect(ls.create(:verbose => !original).verbose).not_to eq(original)
+      expect(ls.create(verbose: !original).verbose).not_to eq(original)
     end
 
-    it 'should set the sitemaps_path' do
+    it 'sets the sitemaps_path' do
       path = 'new/path'
-      ls.create(:sitemaps_path => path)
+      ls.create(sitemaps_path: path)
       expect(ls.sitemaps_path).to eq(path)
       expect(ls.sitemap.location.sitemaps_path.to_s).to eq('new/path/')
     end
 
-    it 'should set the default_host' do
+    it 'sets the default_host' do
       host = 'http://defaulthost.com'
-      ls.create(:default_host => host)
+      ls.create(default_host: host)
       expect(ls.default_host).to eq(host)
       expect(ls.sitemap.location.host).to eq(host)
     end
 
-    it 'should set the sitemaps host' do
+    it 'sets the sitemaps host' do
       host = 'http://sitemaphost.com'
-      ls.create(:sitemaps_host => host)
+      ls.create(sitemaps_host: host)
       expect(ls.sitemaps_host).to eq(host)
       expect(ls.sitemap.location.host).to eq(host)
     end
 
-    it 'should set the namer' do
+    it 'sets the namer' do
       namer = SitemapGenerator::SimpleNamer.new(:xxx)
-      ls.create(:namer => namer)
+      ls.create(namer: namer)
       expect(ls.namer).to eq(namer)
       expect(ls.sitemap.location.namer).to eq(namer)
       expect(ls.sitemap.location.filename).to match(/xxx/)
     end
 
-    it 'should support both namer and filename options' do
+    it 'supports both namer and filename options' do
       namer = SitemapGenerator::SimpleNamer.new('sitemap2')
-      ls.create(:namer => namer, :filename => 'sitemap1')
+      ls.create(namer: namer, filename: 'sitemap1')
       expect(ls.namer).to eq(namer)
       expect(ls.sitemap.location.namer).to eq(namer)
       expect(ls.sitemap.location.filename).to match(/^sitemap2/)
       expect(ls.sitemap_index.location.filename).to match(/^sitemap2/)
     end
 
-    it 'should support both namer and filename options no matter the order' do
+    it 'supports both namer and filename options no matter the order' do
       options = {
-        :namer => SitemapGenerator::SimpleNamer.new('sitemap1'),
-        :filename => 'sitemap2'
+        namer: SitemapGenerator::SimpleNamer.new('sitemap1'),
+        filename: 'sitemap2'
       }
       ls.create(options)
       expect(ls.sitemap.location.filename).to match(/^sitemap1/)
       expect(ls.sitemap_index.location.filename).to match(/^sitemap1/)
     end
 
-    it 'should not modify the options hash' do
-      options = { :filename => 'sitemaptest', :verbose => false }
+    it 'does not modify the options hash' do
+      options = { filename: 'sitemaptest', verbose: false }
       ls.create(options)
-      expect(options).to eq({ :filename => 'sitemaptest', :verbose => false })
+      expect(options).to eq({ filename: 'sitemaptest', verbose: false })
     end
 
-    it 'should set create_index' do
-      ls.create(:create_index => :auto)
+    it 'sets create_index' do
+      ls.create(create_index: :auto)
       expect(ls.create_index).to eq(:auto)
     end
 
-    it 'should not call finalize!' do
-      expect(ls).to receive(:finalize!).never
+    it 'does not call finalize!' do
+      expect(ls).not_to receive(:finalize!)
       ls.create({})
     end
 
     context 'when block is given' do
-      it 'should finalize! after the block' do
+      it 'finalize!s after the block' do
         expect(ls).to receive(:finalize!)
         ls.create do
           add('/test')
@@ -578,34 +582,38 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'reset!' do
-    it 'should reset the sitemap namer' do
+    it 'resets the sitemap namer' do
       expect(SitemapGenerator::Sitemap.namer).to receive(:reset)
-      SitemapGenerator::Sitemap.create(:default_host => 'http://cnn.com')
+      SitemapGenerator::Sitemap.create(default_host: 'http://cnn.com')
     end
 
-    it 'should reset the default link variable' do
-      SitemapGenerator::Sitemap.instance_variable_set(:@added_default_links, true)
-      SitemapGenerator::Sitemap.create(:default_host => 'http://cnn.com')
-      SitemapGenerator::Sitemap.instance_variable_set(:@added_default_links, false)
+    it 'resets the default link variable' do
+      # SitemapGenerator::Sitemap delegates via method_missing to an internal @link_set;
+      # instance_variable_get/set on Sitemap itself would silently touch the wrong object.
+      SitemapGenerator::Sitemap.namer # ensure @link_set is lazily initialized
+      link_set = SitemapGenerator::Sitemap.instance_variable_get(:@link_set)
+      link_set.instance_variable_set(:@added_default_links, true)
+      SitemapGenerator::Sitemap.create(default_host: 'http://cnn.com')
+      expect(link_set.instance_variable_get(:@added_default_links)).to be(false)
     end
   end
 
   describe 'include_root?' do
-    it 'should return false' do
+    it 'returns false' do
       ls.include_root = false
       expect(ls.include_root).to be(false)
     end
 
-    it 'should return true' do
+    it 'returns true' do
       ls.include_root = true
       expect(ls.include_root).to be(true)
     end
   end
 
   describe 'include_index?' do
-    let(:sitemaps_host)  { 'http://amazon.com' }
+    let(:sitemaps_host) { 'http://amazon.com' }
 
-    it 'should be true if no sitemaps_host set, or it is the same' do
+    it 'is true if no sitemaps_host set, or it is the same' do
       ls.include_index = true
       ls.sitemaps_host = default_host
       expect(ls.include_index?).to be(true)
@@ -614,7 +622,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       expect(ls.include_index?).to be(true)
     end
 
-    it 'should be false if include_index is false or sitemaps_host differs' do
+    it 'is false if include_index is false or sitemaps_host differs' do
       ls.include_index = false
       ls.sitemaps_host = default_host
       expect(ls.include_index?).to be(false)
@@ -624,20 +632,20 @@ RSpec.describe SitemapGenerator::LinkSet do
       expect(ls.include_index?).to be(false)
     end
 
-    it 'should return false' do
-      ls = SitemapGenerator::LinkSet.new(:default_host => default_host, :sitemaps_host => sitemaps_host)
+    it 'returns false' do
+      ls = described_class.new(default_host: default_host, sitemaps_host: sitemaps_host)
       expect(ls.include_index?).to be(false)
     end
   end
 
   describe 'output' do
-    it 'should not output' do
+    it 'does not output' do
       ls.verbose = false
-      expect(ls).to receive(:puts).never
+      expect(ls).not_to receive(:puts)
       ls.send(:output, '')
     end
 
-    it 'should print the given string' do
+    it 'prints the given string' do
       ls.verbose = true
       expect(ls).to receive(:puts).with('')
       ls.send(:output, '')
@@ -645,139 +653,142 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'yield_sitemap' do
-    it 'should default to the value of SitemapGenerator.yield_sitemap?' do
+    it 'defaults to the value of SitemapGenerator.yield_sitemap?' do
       expect(SitemapGenerator).to receive(:yield_sitemap?).and_return(true)
       expect(ls.yield_sitemap?).to be(true)
       expect(SitemapGenerator).to receive(:yield_sitemap?).and_return(false)
       expect(ls.yield_sitemap?).to be(false)
     end
 
-    it 'should be settable as an option' do
-      expect(SitemapGenerator).to receive(:yield_sitemap?).never
-      expect(SitemapGenerator::LinkSet.new(:yield_sitemap => true).yield_sitemap?).to be(true)
-      expect(SitemapGenerator::LinkSet.new(:yield_sitemap => false).yield_sitemap?).to be(false)
+    it 'is settable as an option' do
+      expect(SitemapGenerator).not_to receive(:yield_sitemap?)
+      expect(described_class.new(yield_sitemap: true).yield_sitemap?).to be(true)
+      expect(described_class.new(yield_sitemap: false).yield_sitemap?).to be(false)
     end
 
-    it 'should be settable as an attribute' do
+    it 'is settable as an attribute' do
       ls.yield_sitemap = true
       expect(ls.yield_sitemap?).to be(true)
       ls.yield_sitemap = false
       expect(ls.yield_sitemap?).to be(false)
     end
 
-    it 'should yield the sitemap in the call to create' do
-      expect(ls.send(:interpreter)).to receive(:eval).with(:yield_sitemap => true)
+    it 'yields the sitemap in the call to create' do
+      expect(ls.send(:interpreter)).to receive(:eval).with(yield_sitemap: true)
       ls.yield_sitemap = true
       ls.create
-      expect(ls.send(:interpreter)).to receive(:eval).with(:yield_sitemap => false)
+      expect(ls.send(:interpreter)).to receive(:eval).with(yield_sitemap: false)
       ls.yield_sitemap = false
       ls.create
     end
   end
 
   describe 'add' do
-    it 'should not modify the options hash' do
-      options = { :host => 'http://newhost.com' }
+    it 'does not modify the options hash' do
+      options = { host: 'http://newhost.com' }
       ls.add('/home', options)
-      expect(options).to eq({ :host => 'http://newhost.com' })
+      expect(options).to eq({ host: 'http://newhost.com' })
     end
 
-    it 'should add the link to the sitemap and include the default host' do
+    it 'adds the link to the sitemap and include the default host' do
       expect(ls).to receive(:add_default_links)
-      expect(ls.sitemap).to receive(:add).with('/home', { :host => ls.default_host })
+      expect(ls.sitemap).to receive(:add).with('/home', { host: ls.default_host })
       ls.add('/home')
     end
 
-    it 'should allow setting of a custom host' do
+    it 'allows setting of a custom host' do
       expect(ls).to receive(:add_default_links)
-      expect(ls.sitemap).to receive(:add).with('/home', { :host => 'http://newhost.com' })
-      ls.add('/home', :host => 'http://newhost.com')
+      expect(ls.sitemap).to receive(:add).with('/home', { host: 'http://newhost.com' })
+      ls.add('/home', host: 'http://newhost.com')
     end
 
-    it 'should add the default links if they have not been added' do
+    it 'adds the default links if they have not been added' do
       expect(ls).to receive(:add_default_links)
       ls.add('/home')
     end
   end
 
   describe 'add_to_index' do
-    it 'should add the link to the sitemap index and pass options' do
-      expect(ls.sitemap_index).to receive(:add).with('/test', hash_including(:option => 'value'))
-      ls.add_to_index('/test', :option => 'value')
+    it 'adds the link to the sitemap index and pass options' do
+      expect(ls.sitemap_index).to receive(:add).with('/test', hash_including(option: 'value'))
+      ls.add_to_index('/test', option: 'value')
     end
 
-    it 'should not modify the options hash' do
-      options = { :host => 'http://newhost.com' }
+    it 'does not modify the options hash' do
+      options = { host: 'http://newhost.com' }
       ls.add_to_index('/home', options)
-      expect(options).to eq({ :host => 'http://newhost.com' })
+      expect(options).to eq({ host: 'http://newhost.com' })
     end
 
     describe 'host' do
-      it 'should be the sitemaps_host' do
+      it 'is the sitemaps_host' do
         ls.sitemaps_host = 'http://sitemapshost.com'
-        expect(ls.sitemap_index).to receive(:add).with('/home', { :host => 'http://sitemapshost.com' })
+        expect(ls.sitemap_index).to receive(:add).with('/home', { host: 'http://sitemapshost.com' })
         ls.add_to_index('/home')
       end
 
-      it 'should be the default_host if no sitemaps_host set' do
-        expect(ls.sitemap_index).to receive(:add).with('/home', { :host => ls.default_host })
+      it 'is the default_host if no sitemaps_host set' do
+        expect(ls.sitemap_index).to receive(:add).with('/home', { host: ls.default_host })
         ls.add_to_index('/home')
       end
 
-      it 'should allow setting a custom host' do
-        expect(ls.sitemap_index).to receive(:add).with('/home', { :host => 'http://newhost.com' })
-        ls.add_to_index('/home', :host => 'http://newhost.com')
+      it 'allows setting a custom host' do
+        expect(ls.sitemap_index).to receive(:add).with('/home', { host: 'http://newhost.com' })
+        ls.add_to_index('/home', host: 'http://newhost.com')
       end
     end
   end
 
   describe 'create_index' do
-    let(:location) { SitemapGenerator::SitemapLocation.new(:namer => SitemapGenerator::SimpleNamer.new(:sitemap), :public_path => 'tmp/', :sitemaps_path => 'test/', :host => 'http://example.com/') }
+    let(:location) do
+      SitemapGenerator::SitemapLocation.new(namer: SitemapGenerator::SimpleNamer.new(:sitemap), public_path: 'tmp/',
+                                            sitemaps_path: 'test/', host: 'http://example.com/')
+    end
     let(:sitemap)  { SitemapGenerator::Builder::SitemapFile.new(location) }
 
     describe 'when false' do
-      let(:ls)  { SitemapGenerator::LinkSet.new(:default_host => default_host, :create_index => false) }
+      let(:ls) { described_class.new(default_host: default_host, create_index: false) }
 
-      it 'should not write the index' do
+      it 'does not write the index' do
         ls.send(:finalize_sitemap_index!)
         expect(ls.sitemap_index.written?).to be(false)
       end
 
-      it 'should still add finalized sitemaps to the index (but the index is never finalized)' do
+      it 'still adds finalized sitemaps to the index (but the index is never finalized)' do
         expect(ls).to receive(:add_to_index).with(ls.sitemap).once
         ls.send(:finalize_sitemap!)
       end
     end
 
     describe 'when true' do
-      let(:ls)  { SitemapGenerator::LinkSet.new(:default_host => default_host, :create_index => true) }
+      let(:ls) { described_class.new(default_host: default_host, create_index: true) }
 
-      it 'should always finalize the index' do
+      it 'always finalizes the index' do
         ls.send(:finalize_sitemap_index!)
         expect(ls.sitemap_index.finalized?).to be(true)
       end
 
-      it 'should add finalized sitemaps to the index' do
+      it 'adds finalized sitemaps to the index' do
         expect(ls).to receive(:add_to_index).with(ls.sitemap).once
         ls.send(:finalize_sitemap!)
       end
     end
 
     describe 'when :auto' do
-      let(:ls)  { SitemapGenerator::LinkSet.new(:default_host => default_host, :create_index => :auto) }
+      let(:ls) { described_class.new(default_host: default_host, create_index: :auto) }
 
-      it 'should not write the index when it is empty' do
+      it 'does not write the index when it is empty' do
         expect(ls.sitemap_index.empty?).to be(true)
         ls.send(:finalize_sitemap_index!)
         expect(ls.sitemap_index.written?).to be(false)
       end
 
-      it 'should add finalized sitemaps to the index' do
+      it 'adds finalized sitemaps to the index' do
         expect(ls).to receive(:add_to_index).with(ls.sitemap).once
         ls.send(:finalize_sitemap!)
       end
 
-      it 'should write the index when a link is added manually' do
+      it 'writes the index when a link is added manually' do
         ls.sitemap_index.add '/test'
         expect(ls.sitemap_index.empty?).to be(false)
         ls.send(:finalize_sitemap_index!)
@@ -787,7 +798,7 @@ RSpec.describe SitemapGenerator::LinkSet do
         expect(ls.sitemap_index.index_url).to eq('http://example.com/sitemap.xml.gz')
       end
 
-      it 'should not write the index when only one sitemap is added (considered internal usage)' do
+      it 'does not write the index when only one sitemap is added (considered internal usage)' do
         ls.sitemap_index.add sitemap
         expect(ls.sitemap_index.empty?).to be(false)
         ls.send(:finalize_sitemap_index!)
@@ -797,7 +808,7 @@ RSpec.describe SitemapGenerator::LinkSet do
         expect(ls.sitemap_index.index_url).to eq(sitemap.location.url)
       end
 
-      it 'should write the index when more than one sitemap is added (considered internal usage)' do
+      it 'writes the index when more than one sitemap is added (considered internal usage)' do
         ls.sitemap_index.add sitemap
         ls.sitemap_index.add sitemap.new
         ls.send(:finalize_sitemap_index!)
@@ -808,7 +819,7 @@ RSpec.describe SitemapGenerator::LinkSet do
         expect(ls.sitemap_index.index_url).to eq('http://example.com/sitemap.xml.gz')
       end
 
-      it 'should write the index when it has more than one link' do
+      it 'writes the index when it has more than one link' do
         ls.sitemap_index.add '/test1'
         ls.sitemap_index.add '/test2'
         ls.send(:finalize_sitemap_index!)
@@ -825,13 +836,13 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls.include_root = false
     end
 
-    it 'should not be written' do
+    it 'is not written' do
       expect(ls.sitemap.empty?).to be(true)
-      expect(ls).to receive(:add_to_index).never
+      expect(ls).not_to receive(:add_to_index)
       ls.send(:finalize_sitemap!)
     end
 
-    it 'should be written' do
+    it 'is written' do
       ls.sitemap.add '/test'
       expect(ls.sitemap.empty?).to be(false)
       expect(ls).to receive(:add_to_index).with(ls.sitemap)
@@ -840,36 +851,36 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'compress' do
-    it 'should be true by default' do
+    it 'is true by default' do
       expect(ls.compress).to be(true)
     end
 
-    it 'should be set on the location objects' do
+    it 'is set on the location objects' do
       expect(ls.sitemap.location[:compress]).to be(true)
       expect(ls.sitemap_index.location[:compress]).to be(true)
     end
 
-    it 'should be settable and gettable' do
+    it 'is settable and gettable' do
       ls.compress = false
       expect(ls.compress).to be(false)
       ls.compress = :all_but_first
       expect(ls.compress).to eq(:all_but_first)
     end
 
-    it 'should update the location objects when set' do
+    it 'updates the location objects when set' do
       ls.compress = false
       expect(ls.sitemap.location[:compress]).to be(false)
       expect(ls.sitemap_index.location[:compress]).to be(false)
     end
 
     describe 'in groups' do
-      it 'should inherit the current compress setting' do
+      it 'inherits the current compress setting' do
         ls.compress = false
         expect(ls.group.compress).to be(false)
       end
 
-      it 'should set the compress value' do
-        group = ls.group(:compress => false)
+      it 'sets the compress value' do
+        group = ls.group(compress: false)
         expect(group.compress).to be(false)
       end
     end
@@ -877,7 +888,7 @@ RSpec.describe SitemapGenerator::LinkSet do
 
   describe 'max_sitemap_links' do
     it 'can be set via initializer' do
-      ls = SitemapGenerator::LinkSet.new(:max_sitemap_links => 10)
+      ls = described_class.new(max_sitemap_links: 10)
       expect(ls.max_sitemap_links).to eq(10)
     end
 
@@ -888,7 +899,7 @@ RSpec.describe SitemapGenerator::LinkSet do
   end
 
   describe 'options_for_group' do
-    context 'max_sitemap_links' do
+    describe 'max_sitemap_links' do
       it 'inherits the current value' do
         ls.max_sitemap_links = 10
         options = ls.send(:options_for_group, {})
@@ -896,7 +907,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       end
 
       it 'returns the value when set' do
-        options = ls.send(:options_for_group, :max_sitemap_links => 10)
+        options = ls.send(:options_for_group, max_sitemap_links: 10)
         expect(options[:max_sitemap_links]).to eq(10)
       end
     end
@@ -915,14 +926,14 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls.instance_variable_set(:@compress, :compress)
 
       expect(SitemapGenerator::SitemapLocation).to receive(:new).with(
-        :host => :host,
-        :namer => :namer,
-        :public_path => :public_path,
-        :sitemaps_path => :sitemaps_path,
-        :adapter => :adapter,
-        :verbose => :verbose,
-        :compress => :compress,
-        :max_sitemap_links => :max_sitemap_links
+        host: :host,
+        namer: :namer,
+        public_path: :public_path,
+        sitemaps_path: :sitemaps_path,
+        adapter: :adapter,
+        verbose: :verbose,
+        compress: :compress,
+        max_sitemap_links: :max_sitemap_links
       )
       ls.sitemap_location
     end
@@ -943,7 +954,7 @@ RSpec.describe SitemapGenerator::LinkSet do
     end
 
     context 'when include_index is true' do
-      let(:ls) { SitemapGenerator::LinkSet.new(default_host: default_host, include_index: true, include_root: false) }
+      let(:ls) { described_class.new(default_host: default_host, include_index: true, include_root: false) }
 
       it 'adds the sitemap index with lastmod and priority set' do
         expect(ls).to receive(:add).with(ls.sitemap_index, hash_including(lastmod: frozen_time, priority: 1.0))

--- a/spec/sitemap_generator/link_set_spec.rb
+++ b/spec/sitemap_generator/link_set_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SitemapGenerator::LinkSet do
 
   describe 'initializer options' do
     options = %i[public_path sitemaps_path default_host filename search_engines max_sitemap_links]
-    values = [File.expand_path("#{SitemapGenerator.app.root}/tmp/"), 'mobile/', 'http://myhost.com', :xxx,
+    values = [File.expand_path(SitemapGenerator.app.root.join('tmp/')), 'mobile/', 'http://myhost.com', :xxx,
               { abc: '123' }, 10]
 
     options.zip(values).each do |option, value|
@@ -26,7 +26,7 @@ RSpec.describe SitemapGenerator::LinkSet do
     default_options = {
       filename: :sitemap,
       sitemaps_path: nil,
-      public_path: Pathname.new("#{SitemapGenerator.app.root}/public/"),
+      public_path: SitemapGenerator.app.root.join('public/'),
       default_host: nil,
       include_index: false,
       include_root: true,
@@ -46,7 +46,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls = described_class.new(default_host: default_host, include_root: true, include_index: true)
       expect(ls.include_root).to be(true)
       expect(ls.include_index).to be(true)
-      ls.create { |sitemap| }
+      ls.create { |sitemap| sitemap }
       expect(ls.sitemap.link_count).to eq(2)
     end
 
@@ -54,7 +54,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls = described_class.new(default_host: default_host, include_root: false)
       expect(ls.include_root).to be(false)
       expect(ls.include_index).to be(false)
-      ls.create { |sitemap| }
+      ls.create { |sitemap| sitemap }
       expect(ls.sitemap.link_count).to eq(0)
     end
 
@@ -62,7 +62,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls = described_class.new(default_host: default_host, include_index: false)
       expect(ls.include_root).to be(true)
       expect(ls.include_index).to be(false)
-      ls.create { |sitemap| }
+      ls.create { |sitemap| sitemap }
       expect(ls.sitemap.link_count).to eq(1)
     end
 
@@ -70,21 +70,21 @@ RSpec.describe SitemapGenerator::LinkSet do
       ls = described_class.new(default_host: default_host, include_root: false, include_index: false)
       expect(ls.include_root).to be(false)
       expect(ls.include_index).to be(false)
-      ls.create { |sitemap| }
+      ls.create { |sitemap| sitemap }
       expect(ls.sitemap.link_count).to eq(0)
     end
   end
 
   describe 'sitemaps public_path' do
     it 'defaults to public/' do
-      path = Pathname.new("#{SitemapGenerator.app.root}/public/")
+      path = SitemapGenerator.app.root.join('public/')
       expect(ls.public_path).to eq(path)
       expect(ls.sitemap.location.public_path).to eq(path)
       expect(ls.sitemap_index.location.public_path).to eq(path)
     end
 
     it 'changes when the public_path is changed' do
-      path = Pathname.new("#{SitemapGenerator.app.root}/tmp/")
+      path = SitemapGenerator.app.root.join('tmp/')
       ls.public_path = 'tmp/'
       expect(ls.public_path).to eq(path)
       expect(ls.sitemap.location.public_path).to eq(path)
@@ -92,7 +92,7 @@ RSpec.describe SitemapGenerator::LinkSet do
     end
 
     it 'appends a slash to the path' do
-      path = Pathname.new("#{SitemapGenerator.app.root}/tmp/")
+      path = SitemapGenerator.app.root.join('tmp/')
       ls.public_path = 'tmp'
       expect(ls.public_path).to eq(path)
       expect(ls.sitemap.location.public_path).to eq(path)
@@ -372,11 +372,11 @@ RSpec.describe SitemapGenerator::LinkSet do
 
       it 'finalizes the sitemap if it is the only option' do
         expect(ls).to receive(:finalize_sitemap!)
-        ls.group(sitemaps_host: 'http://test.com') {}
+        ls.group(sitemaps_host: 'http://test.com') { nil }
       end
 
       it 'uses the same namer' do
-        @group = ls.group(sitemaps_host: 'http://test.com') {}
+        @group = ls.group(sitemaps_host: 'http://test.com') { nil }
         expect(@group.sitemap.location.namer).to eq(ls.sitemap.location.namer)
       end
     end
@@ -436,7 +436,7 @@ RSpec.describe SitemapGenerator::LinkSet do
       end
 
       it 'does not finalize the sitemap if a group is created' do
-        ls.create { group {} }
+        ls.create { group { nil } }
         expect(ls.sitemap.empty?).to be(true)
         expect(ls.sitemap.finalized?).to be(false)
       end
@@ -446,7 +446,7 @@ RSpec.describe SitemapGenerator::LinkSet do
         namer: SitemapGenerator::SimpleNamer.new(:sitemap) }.each do |k, v|
         it "does not finalize the sitemap if #{k} is present" do
           expect(ls).not_to receive(:finalize_sitemap!)
-          ls.group(k => v) {}
+          ls.group(k => v) { nil }
         end
       end
     end
@@ -469,12 +469,12 @@ RSpec.describe SitemapGenerator::LinkSet do
 
   describe 'after create' do
     it 'finalizes the sitemap index' do
-      ls.create {}
+      ls.create { nil }
       expect(ls.sitemap_index.finalized?).to be(true)
     end
 
     it 'finalizes the sitemap' do
-      ls.create {}
+      ls.create { nil }
       expect(ls.sitemap.finalized?).to be(true)
     end
 

--- a/spec/sitemap_generator/sitemap_generator_spec.rb
+++ b/spec/sitemap_generator/sitemap_generator_spec.rb
@@ -553,7 +553,7 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'respond_to?' do
-    it 'correctlies identify the methods that it responds to' do
+    it 'correctly identifies the methods that it responds to' do
       expect(SitemapGenerator::Sitemap.respond_to?(:create)).to be(true)
       expect(SitemapGenerator::Sitemap.respond_to?(:adapter)).to be(true)
       expect(SitemapGenerator::Sitemap.respond_to?(:default_host)).to be(true)

--- a/spec/sitemap_generator/sitemap_generator_spec.rb
+++ b/spec/sitemap_generator/sitemap_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'uri'
 
@@ -15,7 +17,7 @@ RSpec.describe 'SitemapGenerator' do
       SitemapGenerator::Sitemap.default_host # Force initialization of the LinkSet
     end
 
-    it 'should set a new LinkSet instance' do
+    it 'sets a new LinkSet instance' do
       first = SitemapGenerator::Sitemap.instance_variable_get(:@link_set)
       expect(first).to be_a(SitemapGenerator::LinkSet)
       SitemapGenerator::Sitemap.reset!
@@ -26,8 +28,8 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'root' do
-    it 'should be set to the root of the gem' do
-      expect(SitemapGenerator.root).to eq(File.expand_path('../../../' , __FILE__))
+    it 'is set to the root of the gem' do
+      expect(SitemapGenerator.root).to eq(File.expand_path('../..', __dir__))
     end
   end
 
@@ -43,14 +45,14 @@ RSpec.describe 'SitemapGenerator' do
       delete_sitemap_file_from_rails_app
     end
 
-    it 'should create sitemaps' do
+    it 'creates sitemaps' do
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_exist(rails_path('public/sitemap1.xml.gz'))
       file_should_exist(rails_path('public/sitemap2.xml.gz'))
       file_should_not_exist(rails_path('public/sitemap3.xml.gz'))
     end
 
-    it 'should have 13 links' do
+    it 'has 13 links' do
       expect(SitemapGenerator::Sitemap.link_count).to eq(13)
     end
 
@@ -87,7 +89,8 @@ RSpec.describe 'SitemapGenerator' do
         public/fr/new_sitemaps1.xml.gz
         public/fr/new_sitemaps2.xml.gz
         public/fr/new_sitemaps3.xml.gz
-        public/fr/new_sitemaps4.xml.gz]
+        public/fr/new_sitemaps4.xml.gz
+      ]
       @sitemaps = (@expected - %w[public/fr/new_sitemaps.xml.gz])
     end
 
@@ -95,14 +98,14 @@ RSpec.describe 'SitemapGenerator' do
       delete_sitemap_file_from_rails_app
     end
 
-    it 'should create sitemaps' do
+    it 'creates sitemaps' do
       @expected.each { |file| file_should_exist(rails_path(file)) }
       file_should_not_exist(rails_path('public/fr/new_sitemaps5.xml.gz'))
       file_should_not_exist(rails_path('public/en/xxx1.xml.gz'))
       file_should_not_exist(rails_path('public/fr/abc5.xml.gz'))
     end
 
-    it 'should have 16 links' do
+    it 'has 16 links' do
       expect(SitemapGenerator::Sitemap.link_count).to eq(16)
     end
 
@@ -123,21 +126,21 @@ RSpec.describe 'SitemapGenerator' do
     end
   end
 
-  describe 'should handle links added manually' do
+  describe 'links added manually with a custom starting index' do
     before do
       clean_sitemap_files_from_rails_app
-      ::SitemapGenerator::Sitemap.reset!
-      ::SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
-      ::SitemapGenerator::Sitemap.namer = ::SitemapGenerator::SimpleNamer.new(:sitemap, :start => 4)
-      ::SitemapGenerator::Sitemap.create do
+      SitemapGenerator::Sitemap.reset!
+      SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
+      SitemapGenerator::Sitemap.namer = SitemapGenerator::SimpleNamer.new(:sitemap, start: 4)
+      SitemapGenerator::Sitemap.create do
         3.times do |i|
-          add_to_index 'sitemap#{i}.xml.gz'
+          add_to_index "sitemap#{i}.xml.gz"
         end
         add '/home'
       end
     end
 
-    it 'should create the index and start the sitemap numbering from 4' do
+    it 'creates the index and start the sitemap numbering from 4' do
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_exist(rails_path('public/sitemap4.xml.gz'))
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'siteindex'
@@ -145,22 +148,22 @@ RSpec.describe 'SitemapGenerator' do
     end
   end
 
-  describe 'should handle links added manually' do
+  describe 'create_index behavior with manually added links' do
     before do
       clean_sitemap_files_from_rails_app
-      ::SitemapGenerator::Sitemap.reset!
-      ::SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
-      ::SitemapGenerator::Sitemap.include_root = false
+      SitemapGenerator::Sitemap.reset!
+      SitemapGenerator::Sitemap.default_host = 'http://www.example.com'
+      SitemapGenerator::Sitemap.include_root = false
     end
 
-    it 'should create the index' do
-      with_max_links(1) {
-        ::SitemapGenerator::Sitemap.create do
+    it 'creates the index when add_to_index is called before the sitemap links' do
+      with_max_links(1) do
+        SitemapGenerator::Sitemap.create do
           add_to_index 'customsitemap.xml.gz'
           add '/one'
           add '/two'
         end
-      }
+      end
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_exist(rails_path('public/sitemap1.xml.gz'))
       file_should_exist(rails_path('public/sitemap2.xml.gz'))
@@ -168,14 +171,14 @@ RSpec.describe 'SitemapGenerator' do
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'siteindex'
     end
 
-    it 'should create the index' do
-      with_max_links(1) {
-        ::SitemapGenerator::Sitemap.create do
+    it 'creates the index when add_to_index is called between the sitemap links' do
+      with_max_links(1) do
+        SitemapGenerator::Sitemap.create do
           add '/one'
           add_to_index 'customsitemap.xml.gz'
           add '/two'
         end
-      }
+      end
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_exist(rails_path('public/sitemap1.xml.gz'))
       file_should_exist(rails_path('public/sitemap2.xml.gz'))
@@ -183,34 +186,34 @@ RSpec.describe 'SitemapGenerator' do
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'siteindex'
     end
 
-    it 'should create an index when only manually added links' do
-      with_max_links(1) {
-        ::SitemapGenerator::Sitemap.create(:create_index => :auto) do
+    it 'creates an index for a single manually added link' do
+      with_max_links(1) do
+        SitemapGenerator::Sitemap.create(create_index: :auto) do
           add_to_index 'customsitemap1.xml.gz'
         end
-      }
+      end
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_not_exist(rails_path('public/sitemap1.xml.gz'))
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'siteindex'
     end
 
-    it 'should create an index when only manually added links' do
-      with_max_links(1) {
-        ::SitemapGenerator::Sitemap.create(:create_index => :auto) do
+    it 'creates an index for multiple manually added links' do
+      with_max_links(1) do
+        SitemapGenerator::Sitemap.create(create_index: :auto) do
           add_to_index 'customsitemap1.xml.gz'
           add_to_index 'customsitemap2.xml.gz'
           add_to_index 'customsitemap3.xml.gz'
         end
-      }
+      end
       file_should_exist(rails_path('public/sitemap.xml.gz'))
       file_should_not_exist(rails_path('public/sitemap1.xml.gz'))
       gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'siteindex'
     end
 
-    it 'should not create an index' do
+    it 'does not create an index or a sitemap when only manually added links exist' do
       # Create index is explicity turned off and no links added to sitemap,
       # respect the setting and don't create the index.  There is no sitemap file either.
-      ::SitemapGenerator::Sitemap.create(:create_index => false) do
+      SitemapGenerator::Sitemap.create(create_index: false) do
         add_to_index 'customsitemap1.xml.gz'
         add_to_index 'customsitemap2.xml.gz'
         add_to_index 'customsitemap3.xml.gz'
@@ -219,8 +222,8 @@ RSpec.describe 'SitemapGenerator' do
       file_should_not_exist(rails_path('public/sitemap1.xml.gz'))
     end
 
-    it 'should not create an index' do
-      ::SitemapGenerator::Sitemap.create(:create_index => false) do
+    it 'does not create an index when a link is added normally' do
+      SitemapGenerator::Sitemap.create(create_index: false) do
         add '/one'
       end
       file_should_exist(rails_path('public/sitemap.xml.gz')) # the sitemap, not an index
@@ -232,14 +235,14 @@ RSpec.describe 'SitemapGenerator' do
   describe 'sitemap path' do
     before do
       clean_sitemap_files_from_rails_app
-      ::SitemapGenerator::Sitemap.reset!
-      ::SitemapGenerator::Sitemap.default_host = 'http://test.local'
-      ::SitemapGenerator::Sitemap.filename = 'sitemap'
-      ::SitemapGenerator::Sitemap.create_index = true
+      SitemapGenerator::Sitemap.reset!
+      SitemapGenerator::Sitemap.default_host = 'http://test.local'
+      SitemapGenerator::Sitemap.filename = 'sitemap'
+      SitemapGenerator::Sitemap.create_index = true
     end
 
-    it 'should allow changing of the filename' do
-      ::SitemapGenerator::Sitemap.create(:filename => :geo_sitemap) do
+    it 'allows changing of the filename' do
+      SitemapGenerator::Sitemap.create(filename: :geo_sitemap) do
         add '/goerss'
         add '/kml'
       end
@@ -247,10 +250,10 @@ RSpec.describe 'SitemapGenerator' do
       file_should_exist(rails_path('public/geo_sitemap1.xml.gz'))
     end
 
-    it 'should support setting a sitemap path' do
+    it 'supports setting a sitemap path' do
       directory_should_not_exist(rails_path('public/sitemaps/'))
 
-      sm = ::SitemapGenerator::Sitemap
+      sm = SitemapGenerator::Sitemap
       sm.sitemaps_path = 'sitemaps/'
       sm.create do
         add '/'
@@ -261,10 +264,10 @@ RSpec.describe 'SitemapGenerator' do
       file_should_exist(rails_path('public/sitemaps/sitemap1.xml.gz'))
     end
 
-    it 'should support setting a deeply nested sitemap path' do
+    it 'supports setting a deeply nested sitemap path' do
       directory_should_not_exist(rails_path('public/sitemaps/deep/directory'))
 
-      sm = ::SitemapGenerator::Sitemap
+      sm = SitemapGenerator::Sitemap
       sm.sitemaps_path = 'sitemaps/deep/directory/'
       sm.create do
         add '/'
@@ -278,14 +281,14 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'external dependencies' do
-    it 'should work outside of Rails' do
+    it 'works outside of Rails' do
       hide_const('Rails')
-      expect { ::SitemapGenerator::LinkSet.new }.not_to raise_exception
+      expect { SitemapGenerator::LinkSet.new }.not_to raise_exception
     end
   end
 
   describe 'verbose' do
-    it 'should be set via ENV[\'VERBOSE\']' do
+    it "is set via ENV['VERBOSE']" do
       original = SitemapGenerator.verbose
       SitemapGenerator.verbose = nil
       ENV['VERBOSE'] = 'true'
@@ -298,7 +301,7 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'yield_sitemap' do
-    it 'should set the yield_sitemap flag' do
+    it 'sets the yield_sitemap flag' do
       SitemapGenerator.yield_sitemap = false
       expect(SitemapGenerator.yield_sitemap?).to be(false)
       SitemapGenerator.yield_sitemap = true
@@ -308,14 +311,14 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'create_index' do
-    let(:ls) {
+    let(:ls) do
       SitemapGenerator::LinkSet.new(
-        :include_root => false,
-        :default_host => 'http://example.com',
-        :create_index => create_index,
-        :max_sitemap_links => 1
+        include_root: false,
+        default_host: 'http://example.com',
+        create_index: create_index,
+        max_sitemap_links: 1
       )
-    }
+    end
 
     let!(:request) do
       stub_request(:get, "http://google.com/?url=#{URI.encode_www_form_component('http://example.com/sitemap.xml.gz')}")
@@ -328,7 +331,7 @@ RSpec.describe 'SitemapGenerator' do
     describe 'when true' do
       let(:create_index) { true }
 
-      it 'should always create index' do
+      it 'always creates the index when there is only one sitemap' do
         ls.create { add('/one') }
         expect(ls.sitemap_index.link_count).to eq(1) # one sitemap
         file_should_exist(rails_path('public/sitemap.xml.gz'))
@@ -338,13 +341,16 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap1.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
 
-      it 'should always create index' do
-        ls.create { add('/one'); add('/two') }
+      it 'always creates the index when there are multiple sitemaps' do
+        ls.create do
+          add('/one')
+          add('/two')
+        end
         expect(ls.sitemap_index.link_count).to eq(2) # two sitemaps
         file_should_exist(rails_path('public/sitemap.xml.gz'))
         file_should_exist(rails_path('public/sitemap1.xml.gz'))
@@ -354,7 +360,7 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap2.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
@@ -365,7 +371,7 @@ RSpec.describe 'SitemapGenerator' do
     describe 'when false' do
       let(:create_index) { false }
 
-      it 'should never create index' do
+      it 'never creates the index when there is only one sitemap' do
         ls.create { add('/one') }
         expect(ls.sitemap_index.link_count).to eq(1) # one sitemap
         file_should_exist(rails_path('public/sitemap.xml.gz'))
@@ -373,13 +379,16 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
 
-      it 'should never create index' do
-        ls.create { add('/one'); add('/two') }
+      it 'never creates the index when there are multiple sitemaps' do
+        ls.create do
+          add('/one')
+          add('/two')
+        end
         expect(ls.sitemap_index.link_count).to eq(2) # two sitemaps
         file_should_exist(rails_path('public/sitemap.xml.gz'))
         file_should_exist(rails_path('public/sitemap1.xml.gz'))
@@ -388,7 +397,7 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap1.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
@@ -397,7 +406,7 @@ RSpec.describe 'SitemapGenerator' do
     describe 'when :auto' do
       let(:create_index) { :auto }
 
-      it 'should not create index if only one sitemap file' do
+      it 'does not create index if only one sitemap file' do
         ls.create { add('/one') }
         expect(ls.sitemap_index.link_count).to eq(1) # one sitemap
         file_should_exist(rails_path('public/sitemap.xml.gz'))
@@ -405,13 +414,16 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
 
-      it 'should create index if more than one sitemap file' do
-        ls.create { add('/one'); add('/two') }
+      it 'creates index if more than one sitemap file' do
+        ls.create do
+          add('/one')
+          add('/two')
+        end
         expect(ls.sitemap_index.link_count).to eq(2) # two sitemaps
         file_should_exist(rails_path('public/sitemap.xml.gz'))
         file_should_exist(rails_path('public/sitemap1.xml.gz'))
@@ -422,15 +434,15 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/sitemap2.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
 
-      it 'should create index if more than one group' do
+      it 'creates index if more than one group' do
         ls.create do
-          group(:filename => :group1) { add('/one') };
-          group(:filename => :group2) { add('/two') };
+          group(filename: :group1) { add('/one') }
+          group(filename: :group2) { add('/two') }
         end
         expect(ls.sitemap_index.link_count).to eq(2) # two sitemaps
         file_should_exist(rails_path('public/sitemap.xml.gz'))
@@ -441,7 +453,7 @@ RSpec.describe 'SitemapGenerator' do
         gzipped_xml_file_should_validate_against_schema rails_path('public/group2.xml.gz'), 'sitemap'
 
         # Test that the index url is reported correctly
-        ls.search_engines = { :google => 'http://google.com/?url=%s' }
+        ls.search_engines = { google: 'http://google.com/?url=%s' }
         ls.ping_search_engines
         expect(request).to have_been_requested.once
       end
@@ -449,14 +461,14 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'compress' do
-    let(:ls) {
+    let(:ls) do
       SitemapGenerator::LinkSet.new(
-        :default_host => 'http://test.local',
-        :include_root => false,
-        :compress => compress,
-        :max_sitemap_links => 1
+        default_host: 'http://test.local',
+        include_root: false,
+        compress: compress,
+        max_sitemap_links: 1
       )
-    }
+    end
 
     before do
       clean_sitemap_files_from_rails_app
@@ -465,14 +477,14 @@ RSpec.describe 'SitemapGenerator' do
     describe 'when false' do
       let(:compress) { false }
 
-      it 'should not compress files' do
+      it 'does not compress files' do
         ls.create do
           add('/one')
           add('/two')
-          group(:filename => :group) {
+          group(filename: :group) do
             add('/group1')
             add('/group2')
-          }
+          end
         end
         file_should_exist(rails_path('public/sitemap.xml'))
         file_should_exist(rails_path('public/sitemap1.xml'))
@@ -484,23 +496,23 @@ RSpec.describe 'SitemapGenerator' do
     describe 'when :all_but_first' do
       let(:compress) { :all_but_first }
 
-      it 'should not compress first file' do
+      it 'does not compress first file' do
         ls.create do
           add('/one')
           add('/two')
           add('/three')
-          group(:filename => :group) {
+          group(filename: :group) do
             add('/group1')
             add('/group2')
-          }
-          group(:filename => :group2, :compress => true) {
+          end
+          group(filename: :group2, compress: true) do
             add('/group1')
             add('/group2')
-          }
-          group(:filename => :group2, :compress => false) {
+          end
+          group(filename: :group2, compress: false) do
             add('/group1')
             add('/group2')
-          }
+          end
         end
         file_should_exist(rails_path('public/sitemap.xml'))
         file_should_exist(rails_path('public/sitemap1.xml.gz'))
@@ -515,20 +527,20 @@ RSpec.describe 'SitemapGenerator' do
     describe 'in groups' do
       let(:compress) { nil }
 
-      it 'should respect passed in compress option' do
+      it 'respects passed in compress option' do
         ls.create do
-          group(:filename => :group1, :compress => :all_but_first) {
+          group(filename: :group1, compress: :all_but_first) do
             add('/group1')
             add('/group2')
-          }
-          group(:filename => :group2, :compress => true) {
+          end
+          group(filename: :group2, compress: true) do
             add('/group1')
             add('/group2')
-          }
-          group(:filename => :group3, :compress => false) {
+          end
+          group(filename: :group3, compress: false) do
             add('/group1')
             add('/group2')
-          }
+          end
         end
         file_should_exist(rails_path('public/group1.xml'))
         file_should_exist(rails_path('public/group11.xml.gz'))
@@ -541,7 +553,7 @@ RSpec.describe 'SitemapGenerator' do
   end
 
   describe 'respond_to?' do
-    it 'should correctly identify the methods that it responds to' do
+    it 'correctlies identify the methods that it responds to' do
       expect(SitemapGenerator::Sitemap.respond_to?(:create)).to be(true)
       expect(SitemapGenerator::Sitemap.respond_to?(:adapter)).to be(true)
       expect(SitemapGenerator::Sitemap.respond_to?(:default_host)).to be(true)

--- a/spec/sitemap_generator/sitemap_groups_spec.rb
+++ b/spec/sitemap_generator/sitemap_groups_spec.rb
@@ -1,140 +1,142 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-RSpec.describe 'Sitemap Groups' do
-  let(:linkset) { ::SitemapGenerator::LinkSet.new(:default_host => 'http://test.com') }
+RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feature-level spec, not scoped to one class
+  let(:linkset) { SitemapGenerator::LinkSet.new(default_host: 'http://test.com') }
 
   before do
-    FileUtils.rm_rf(SitemapGenerator.app.root + 'public/')
+    FileUtils.rm_rf("#{SitemapGenerator.app.root}/public/")
   end
 
-  it 'should not finalize the default sitemap if using groups' do
+  it 'does not finalize the default sitemap if using groups' do
     linkset.create do
-      group(:filename => :sitemap_en) do
+      group(filename: :sitemap_en) do
         add '/en'
       end
     end
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap_en.xml.gz')
-    file_should_not_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap_en.xml.gz")
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
   end
 
-  it 'should not write out empty groups' do
+  it 'does not write out empty groups' do
     linkset.create do
-      group(:filename => :sitemap_en) { }
+      group(filename: :sitemap_en) {}
     end
-    file_should_not_exist(SitemapGenerator.app.root + 'public/sitemap_en.xml.gz')
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap_en.xml.gz")
   end
 
-  it 'should add default links if no groups are created' do
+  it 'adds default links if no groups are created' do
     linkset.create do
     end
     expect(linkset.link_count).to eq(1)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_not_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
   end
 
-  it 'should add links to the default sitemap' do
+  it 'adds links to the default sitemap' do
     linkset.create do
       add '/before'
-      group(:filename => :sitemap_en) do
+      group(filename: :sitemap_en) do
         add '/link'
       end
       add '/after'
     end
     expect(linkset.link_count).to eq(4)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap_en.xml.gz')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap_en.xml.gz")
   end
 
-  it 'should rollover when sitemaps are full' do
+  it 'rollovers when sitemaps are full' do
     linkset.max_sitemap_links = 1
     linkset.include_index = false
     linkset.include_root = false
     linkset.create do
       add '/before'
-      group(:filename => :sitemap_en, :sitemaps_path => 'en/') do
+      group(filename: :sitemap_en, sitemaps_path: 'en/') do
         add '/one'
         add '/two'
       end
       add '/after'
     end
     expect(linkset.link_count).to eq(4)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap2.xml.gz')
-    file_should_not_exist(SitemapGenerator.app.root + 'public/sitemap3.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/en/sitemap_en.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/en/sitemap_en1.xml.gz')
-    file_should_not_exist(SitemapGenerator.app.root + 'public/en/sitemap_en2.xml.gz')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz")
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en1.xml.gz")
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en2.xml.gz")
   end
 
-  it 'should support multiple groups' do
+  it 'supports multiple groups' do
     linkset.create do
-      group(:filename => :sitemap_en, :sitemaps_path => 'en/') do
+      group(filename: :sitemap_en, sitemaps_path: 'en/') do
         add '/one'
       end
-      group(:filename => :sitemap_fr, :sitemaps_path => 'fr/') do
+      group(filename: :sitemap_fr, sitemaps_path: 'fr/') do
         add '/one'
       end
     end
     expect(linkset.link_count).to eq(2)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/en/sitemap_en.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/fr/sitemap_fr.xml.gz')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/fr/sitemap_fr.xml.gz")
   end
 
   it 'the sitemap shouldn\'t be finalized until the end if the groups don\'t conflict' do
     linkset.create do
       add 'one'
-      group(:filename => :first) { add '/two' }
+      group(filename: :first) { add '/two' }
       add 'three'
-      group(:filename => :second) { add '/four' }
+      group(filename: :second) { add '/four' }
       add 'five'
     end
     expect(linkset.link_count).to eq(6)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/first.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/second.xml.gz')
-    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root + 'public/sitemap.xml.gz', 'siteindex')
-    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root + 'public/sitemap1.xml.gz', 'sitemap')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/first.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/second.xml.gz")
+    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap.xml.gz", 'siteindex')
+    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz", 'sitemap')
   end
 
   it 'groups should share the sitemap if the sitemap location is unchanged' do
     linkset.create do
       add 'one'
-      group(:default_host => 'http://newhost.com') { add '/two' }
+      group(default_host: 'http://newhost.com') { add '/two' }
       add 'three'
-      group(:default_host => 'http://betterhost.com') { add '/four' }
+      group(default_host: 'http://betterhost.com') { add '/four' }
       add 'five'
     end
     expect(linkset.link_count).to eq(6)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap2.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap3.xml.gz')
-    file_should_not_exist(SitemapGenerator.app.root + 'public/sitemap4.xml.gz')
-    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root + 'public/sitemap.xml.gz', 'siteindex')
-    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root + 'public/sitemap1.xml.gz', 'sitemap')
-    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root + 'public/sitemap2.xml.gz', 'sitemap')
-    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root + 'public/sitemap3.xml.gz', 'sitemap')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz")
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap4.xml.gz")
+    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap.xml.gz", 'siteindex')
+    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz", 'sitemap')
+    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz", 'sitemap')
+    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz", 'sitemap')
   end
 
   it 'sitemaps should be finalized if virtual location settings are changed' do
     linkset.create do
       add 'one'
-      group(:sitemaps_path => :en) { add '/two' }
+      group(sitemaps_path: :en) { add '/two' }
       add 'three'
-      group(:sitemaps_host => 'http://newhost.com') { add '/four' }
+      group(sitemaps_host: 'http://newhost.com') { add '/four' }
       add 'five'
     end
     expect(linkset.link_count).to eq(6)
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap1.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap2.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/sitemap3.xml.gz')
-    file_should_not_exist(SitemapGenerator.app.root + 'public/sitemap4.xml.gz')
-    file_should_exist(SitemapGenerator.app.root + 'public/en/sitemap.xml.gz')
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz")
+    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap4.xml.gz")
+    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap.xml.gz")
   end
 end

--- a/spec/sitemap_generator/sitemap_groups_spec.rb
+++ b/spec/sitemap_generator/sitemap_groups_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
   let(:linkset) { SitemapGenerator::LinkSet.new(default_host: 'http://test.com') }
 
   before do
-    FileUtils.rm_rf("#{SitemapGenerator.app.root}/public/")
+    FileUtils.rm_rf(SitemapGenerator.app.root.join('public/'))
   end
 
   it 'does not finalize the default sitemap if using groups' do
@@ -15,24 +15,23 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
         add '/en'
       end
     end
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap_en.xml.gz")
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap_en.xml.gz'))
+    file_should_not_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
   end
 
   it 'does not write out empty groups' do
     linkset.create do
-      group(filename: :sitemap_en) {}
+      group(filename: :sitemap_en) { nil }
     end
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap_en.xml.gz")
+    file_should_not_exist(SitemapGenerator.app.root.join('public/sitemap_en.xml.gz'))
   end
 
   it 'adds default links if no groups are created' do
-    linkset.create do
-    end
+    linkset.create { nil }
     expect(linkset.link_count).to eq(1)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_not_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
   end
 
   it 'adds links to the default sitemap' do
@@ -44,12 +43,12 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
       add '/after'
     end
     expect(linkset.link_count).to eq(4)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap_en.xml.gz")
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap_en.xml.gz'))
   end
 
-  it 'rollovers when sitemaps are full' do
+  it 'rolls over when sitemaps are full' do
     linkset.max_sitemap_links = 1
     linkset.include_index = false
     linkset.include_root = false
@@ -62,13 +61,13 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
       add '/after'
     end
     expect(linkset.link_count).to eq(4)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz")
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en1.xml.gz")
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en2.xml.gz")
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap2.xml.gz'))
+    file_should_not_exist(SitemapGenerator.app.root.join('public/sitemap3.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/en/sitemap_en.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/en/sitemap_en1.xml.gz'))
+    file_should_not_exist(SitemapGenerator.app.root.join('public/en/sitemap_en2.xml.gz'))
   end
 
   it 'supports multiple groups' do
@@ -81,9 +80,9 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
       end
     end
     expect(linkset.link_count).to eq(2)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap_en.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/fr/sitemap_fr.xml.gz")
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/en/sitemap_en.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/fr/sitemap_fr.xml.gz'))
   end
 
   it 'the sitemap shouldn\'t be finalized until the end if the groups don\'t conflict' do
@@ -95,12 +94,14 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
       add 'five'
     end
     expect(linkset.link_count).to eq(6)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/first.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/second.xml.gz")
-    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap.xml.gz", 'siteindex')
-    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz", 'sitemap')
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/first.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/second.xml.gz'))
+    gzipped_xml_file_should_validate_against_schema(
+      SitemapGenerator.app.root.join('public/sitemap.xml.gz'), 'siteindex'
+    )
+    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'), 'sitemap')
   end
 
   it 'groups should share the sitemap if the sitemap location is unchanged' do
@@ -112,15 +113,17 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
       add 'five'
     end
     expect(linkset.link_count).to eq(6)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz")
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap4.xml.gz")
-    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap.xml.gz", 'siteindex')
-    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz", 'sitemap')
-    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz", 'sitemap')
-    gzipped_xml_file_should_validate_against_schema("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz", 'sitemap')
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap2.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap3.xml.gz'))
+    file_should_not_exist(SitemapGenerator.app.root.join('public/sitemap4.xml.gz'))
+    gzipped_xml_file_should_validate_against_schema(
+      SitemapGenerator.app.root.join('public/sitemap.xml.gz'), 'siteindex'
+    )
+    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'), 'sitemap')
+    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root.join('public/sitemap2.xml.gz'), 'sitemap')
+    gzipped_xml_file_should_validate_against_schema(SitemapGenerator.app.root.join('public/sitemap3.xml.gz'), 'sitemap')
   end
 
   it 'sitemaps should be finalized if virtual location settings are changed' do
@@ -132,11 +135,11 @@ RSpec.describe 'Sitemap Groups' do # rubocop:disable RSpec/DescribeClass -- feat
       add 'five'
     end
     expect(linkset.link_count).to eq(6)
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap1.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap2.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/sitemap3.xml.gz")
-    file_should_not_exist("#{SitemapGenerator.app.root}/public/sitemap4.xml.gz")
-    file_should_exist("#{SitemapGenerator.app.root}/public/en/sitemap.xml.gz")
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap1.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap2.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/sitemap3.xml.gz'))
+    file_should_not_exist(SitemapGenerator.app.root.join('public/sitemap4.xml.gz'))
+    file_should_exist(SitemapGenerator.app.root.join('public/en/sitemap.xml.gz'))
   end
 end

--- a/spec/sitemap_generator/sitemap_location_spec.rb
+++ b/spec/sitemap_generator/sitemap_location_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   let(:default_host) { 'http://example.com' }
 
   it 'public_path should default to the public directory in the application root' do
-    expect(location.public_path).to eq(Pathname.new("#{SitemapGenerator.app.root}/public/"))
+    expect(location.public_path).to eq(SitemapGenerator.app.root.join('public/'))
   end
 
   it 'has a default namer' do

--- a/spec/sitemap_generator/sitemap_location_spec.rb
+++ b/spec/sitemap_generator/sitemap_location_spec.rb
@@ -9,36 +9,36 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   let(:default_host) { 'http://example.com' }
 
   it 'public_path should default to the public directory in the application root' do
-    expect(location.public_path).to eq(SitemapGenerator.app.root + 'public/')
+    expect(location.public_path).to eq(Pathname.new("#{SitemapGenerator.app.root}/public/"))
   end
 
-  it 'should have a default namer' do
+  it 'has a default namer' do
     expect(location[:namer]).not_to be_nil
     expect(location[:filename]).to be_nil
     expect(location.filename).to eq('sitemap1.xml.gz')
   end
 
-  it 'should require a filename' do
+  it 'requires a filename' do
     location[:filename] = nil
-    expect {
+    expect do
       expect(location.filename).to be_nil
-    }.to raise_error(SitemapGenerator::SitemapError, 'No filename or namer set')
+    end.to raise_error(SitemapGenerator::SitemapError, 'No filename or namer set')
   end
 
-  it 'should require a namer' do
+  it 'requires a namer' do
     location[:namer] = nil
-    expect {
+    expect do
       expect(location.filename).to be_nil
-    }.to raise_error(SitemapGenerator::SitemapError, 'No filename or namer set')
+    end.to raise_error(SitemapGenerator::SitemapError, 'No filename or namer set')
   end
 
   context 'when filename and namer are nil' do
     let(:options) { { filename: nil, namer: nil } }
 
-    it 'should require a host' do
-      expect {
+    it 'requires a host' do
+      expect do
         expect(location.host).to be_nil
-      }.to raise_error(SitemapGenerator::SitemapError, 'No value set for host')
+      end.to raise_error(SitemapGenerator::SitemapError, 'No value set for host')
     end
   end
 
@@ -46,17 +46,17 @@ RSpec.describe SitemapGenerator::SitemapLocation do
     let(:namer)   { SitemapGenerator::SimpleNamer.new(:xxx) }
     let(:options) { { namer: namer } }
 
-    it 'should accept a Namer option' do
+    it 'accepts a Namer option' do
       expect(location.filename).to eq(namer.to_s)
     end
 
-    it 'should protect the filename from further changes in the Namer' do
+    it 'protects the filename from further changes in the Namer' do
       expect(location.filename).to eq(namer.to_s)
       namer.next
       expect(location.filename).to eq(namer.previous.to_s)
     end
 
-    it 'should allow changing the namer' do
+    it 'allows changing the namer' do
       expect(location.filename).to eq(namer.to_s)
       namer2 = SitemapGenerator::SimpleNamer.new(:yyy)
       location[:namer] = namer2
@@ -65,33 +65,32 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   end
 
   describe 'testing options and #with' do
-
     # Array of tuples with instance options and expected method return values
     tests = [
       [{
-        :sitemaps_path => nil,
-        :public_path => '/public',
-        :filename => 'sitemap.xml.gz',
-        :host => 'http://test.com' },
-      { :url => 'http://test.com/sitemap.xml.gz',
-        :directory => '/public',
-        :path => '/public/sitemap.xml.gz',
-        :path_in_public => 'sitemap.xml.gz'
-      }],
+        sitemaps_path: nil,
+        public_path: '/public',
+        filename: 'sitemap.xml.gz',
+        host: 'http://test.com'
+      },
+       { url: 'http://test.com/sitemap.xml.gz',
+         directory: '/public',
+         path: '/public/sitemap.xml.gz',
+         path_in_public: 'sitemap.xml.gz' }],
       [{
-        :sitemaps_path => 'sitemaps/en/',
-        :public_path => '/public/system/',
-        :filename => 'sitemap.xml.gz',
-        :host => 'http://test.com/plus/extra/' },
-      { :url => 'http://test.com/plus/extra/sitemaps/en/sitemap.xml.gz',
-        :directory => '/public/system/sitemaps/en',
-        :path => '/public/system/sitemaps/en/sitemap.xml.gz',
-        :path_in_public => 'sitemaps/en/sitemap.xml.gz'
-      }]
+        sitemaps_path: 'sitemaps/en/',
+        public_path: '/public/system/',
+        filename: 'sitemap.xml.gz',
+        host: 'http://test.com/plus/extra/'
+      },
+       { url: 'http://test.com/plus/extra/sitemaps/en/sitemap.xml.gz',
+         directory: '/public/system/sitemaps/en',
+         path: '/public/system/sitemaps/en/sitemap.xml.gz',
+         path_in_public: 'sitemaps/en/sitemap.xml.gz' }]
     ]
     tests.each do |opts, returns|
       returns.each do |method, value|
-        it '#{method} should return #{value}' do
+        it "#{method} should return #{value}" do
           expect(location.with(opts).send(method)).to eq(value)
         end
       end
@@ -101,8 +100,8 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   describe 'when duplicated' do
     let(:options) { { filename: 'xxx', host: default_host, public_path: 'public/' } }
 
-    it 'should not inherit some objects' do
-      expect(location.url).to eq(default_host + '/xxx')
+    it 'does not inherit some objects' do
+      expect(location.url).to eq("#{default_host}/xxx")
       expect(location.public_path.to_s).to eq('public/')
       dup = location.dup
       expect(dup.url).to eq(location.url)
@@ -113,7 +112,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   end
 
   describe 'filesize' do
-    it 'should read the size of the file at path' do
+    it 'reads the size of the file at path' do
       expect(location).to receive(:path).and_return('/somepath')
       expect(File).to receive(:size?).with('/somepath')
       location.filesize
@@ -167,7 +166,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   describe 'public_path' do
     let(:options) { { public_path: 'public/google' } }
 
-    it 'should append a trailing slash' do
+    it 'appends a trailing slash' do
       expect(location.public_path.to_s).to eq('public/google/')
       location[:public_path] = 'new/path'
       expect(location.public_path.to_s).to eq('new/path/')
@@ -179,7 +178,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   describe 'sitemaps_path' do
     let(:options) { { sitemaps_path: 'public/google' } }
 
-    it 'should append a trailing slash' do
+    it 'appends a trailing slash' do
       expect(location.sitemaps_path.to_s).to eq('public/google/')
       location[:sitemaps_path] = 'new/path'
       expect(location.sitemaps_path.to_s).to eq('new/path/')
@@ -191,8 +190,8 @@ RSpec.describe SitemapGenerator::SitemapLocation do
   describe 'url' do
     let(:options) { { public_path: 'public/google', filename: 'xxx', host: default_host, sitemaps_path: 'sub/dir' } }
 
-    it 'should handle paths not ending in slash' do
-      expect(location.url).to eq(default_host + '/sub/dir/xxx')
+    it 'handles paths not ending in slash' do
+      expect(location.url).to eq("#{default_host}/sub/dir/xxx")
     end
   end
 
@@ -206,7 +205,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
     context 'when verbose is true' do
       let(:verbose) { true }
 
-      it 'should output summary line' do
+      it 'outputs summary line' do
         expect(location).to receive(:summary)
         location.write('data', 1)
       end
@@ -215,7 +214,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
     context 'when verbose is false' do
       let(:verbose) { false }
 
-      it 'should not output summary line' do
+      it 'does not output summary line' do
         expect(location).not_to receive(:summary)
         location.write('data', 1)
       end
@@ -226,7 +225,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
     context 'when compress is false' do
       let(:options) { { namer: SitemapGenerator::SimpleNamer.new(:sitemap), compress: false } }
 
-      it 'should strip gz extension if not compressing' do
+      it 'strips gz extension if not compressing' do
         expect(location.filename).to eq('sitemap.xml')
       end
     end
@@ -234,7 +233,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
     context 'when compress is true' do
       let(:options) { { namer: SitemapGenerator::SimpleNamer.new(:sitemap), compress: true } }
 
-      it 'should not strip gz extension if compressing' do
+      it 'does not strip gz extension if compressing' do
         expect(location.filename).to eq('sitemap.xml.gz')
       end
     end
@@ -245,7 +244,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
 
       before { expect(namer).to receive(:start?).and_return(true) }
 
-      it 'should strip gz extension' do
+      it 'strips gz extension' do
         expect(location.filename).to eq('sitemap.xml')
       end
     end
@@ -256,7 +255,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
 
       before { expect(namer).to receive(:start?).and_return(false) }
 
-      it 'should not strip gz extension' do
+      it 'does not strip gz extension' do
         expect(location.filename).to eq('sitemap.xml.gz')
       end
     end
@@ -266,7 +265,7 @@ RSpec.describe SitemapGenerator::SitemapLocation do
     let(:options) { { max_sitemap_links: 10 } }
 
     it 'returns the value set on the object' do
-      location[:max_sitemap_links] = 10
+      expect(location[:max_sitemap_links]).to eq(10)
     end
   end
 
@@ -282,7 +281,7 @@ end
 RSpec.describe SitemapGenerator::SitemapIndexLocation do
   subject(:location) { described_class.new }
 
-  it 'should have a default namer' do
+  it 'has a default namer' do
     expect(location[:namer]).not_to be_nil
     expect(location[:filename]).to be_nil
     expect(location.filename).to eq('sitemap.xml.gz')

--- a/spec/sitemap_generator/sitemap_namer_spec.rb
+++ b/spec/sitemap_generator/sitemap_namer_spec.rb
@@ -1,36 +1,38 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::SimpleNamer do
-  it 'should generate file names' do
-    namer = SitemapGenerator::SimpleNamer.new(:sitemap)
+  it 'generates file names' do
+    namer = described_class.new(:sitemap)
     expect(namer.to_s).to eq('sitemap.xml.gz')
     expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     expect(namer.next.to_s).to eq('sitemap2.xml.gz')
   end
 
-  it 'should set the file extension' do
-    namer = SitemapGenerator::SimpleNamer.new(:sitemap, :extension => '.xyz')
+  it 'sets the file extension' do
+    namer = described_class.new(:sitemap, extension: '.xyz')
     expect(namer.to_s).to eq('sitemap.xyz')
     expect(namer.next.to_s).to eq('sitemap1.xyz')
     expect(namer.next.to_s).to eq('sitemap2.xyz')
   end
 
-  it 'should set the starting index' do
-    namer = SitemapGenerator::SimpleNamer.new(:sitemap, :start => 10)
+  it 'sets the starting index' do
+    namer = described_class.new(:sitemap, start: 10)
     expect(namer.to_s).to eq('sitemap.xml.gz')
     expect(namer.next.to_s).to eq('sitemap10.xml.gz')
     expect(namer.next.to_s).to eq('sitemap11.xml.gz')
   end
 
-  it 'should accept a string name' do
-    namer = SitemapGenerator::SimpleNamer.new('abc-def')
+  it 'accepts a string name' do
+    namer = described_class.new('abc-def')
     expect(namer.to_s).to eq('abc-def.xml.gz')
     expect(namer.next.to_s).to eq('abc-def1.xml.gz')
     expect(namer.next.to_s).to eq('abc-def2.xml.gz')
   end
 
-  it 'should return previous name' do
-    namer = SitemapGenerator::SimpleNamer.new(:sitemap)
+  it 'returns previous name' do
+    namer = described_class.new(:sitemap)
     expect(namer.to_s).to eq('sitemap.xml.gz')
     expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     expect(namer.previous.to_s).to eq('sitemap.xml.gz')
@@ -40,21 +42,21 @@ RSpec.describe SitemapGenerator::SimpleNamer do
     expect(namer.previous.to_s).to eq('sitemap2.xml.gz')
   end
 
-  it 'should raise if already at the start' do
-    namer = SitemapGenerator::SimpleNamer.new(:sitemap)
+  it 'raises if already at the start' do
+    namer = described_class.new(:sitemap)
     expect(namer.to_s).to eq('sitemap.xml.gz')
     # Use a regex because in Ruby 3.1 the error message includes newlines and the first line of backtrace
     expect { namer.previous }.to raise_error(NameError, /Already at the start of the series/)
   end
 
-  it 'should handle names with underscores' do
-    namer = SitemapGenerator::SimpleNamer.new('sitemap1_')
+  it 'handles names with underscores' do
+    namer = described_class.new('sitemap1_')
     expect(namer.to_s).to eq('sitemap1_.xml.gz')
     expect(namer.next.to_s).to eq('sitemap1_1.xml.gz')
   end
 
-  it 'should reset the namer' do
-    namer = SitemapGenerator::SimpleNamer.new(:sitemap)
+  it 'resets the namer' do
+    namer = described_class.new(:sitemap)
     expect(namer.to_s).to eq('sitemap.xml.gz')
     expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     namer.reset
@@ -63,32 +65,32 @@ RSpec.describe SitemapGenerator::SimpleNamer do
   end
 
   describe 'should handle the zero option' do
-    it 'as a string' do
-      namer = SitemapGenerator::SimpleNamer.new(:sitemap, :zero => 'string')
+    it 'as a plain string' do
+      namer = described_class.new(:sitemap, zero: 'string')
       expect(namer.to_s).to eq('sitemapstring.xml.gz')
       expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     end
 
     it 'as an integer' do
-      namer = SitemapGenerator::SimpleNamer.new(:sitemap, :zero => 0)
+      namer = described_class.new(:sitemap, zero: 0)
       expect(namer.to_s).to eq('sitemap0.xml.gz')
       expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     end
 
-    it 'as a string' do
-      namer = SitemapGenerator::SimpleNamer.new(:sitemap, :zero => '_index')
+    it 'as a string with a leading underscore' do
+      namer = described_class.new(:sitemap, zero: '_index')
       expect(namer.to_s).to eq('sitemap_index.xml.gz')
       expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     end
 
     it 'as a symbol' do
-      namer = SitemapGenerator::SimpleNamer.new(:sitemap, :zero => :index)
+      namer = described_class.new(:sitemap, zero: :index)
       expect(namer.to_s).to eq('sitemapindex.xml.gz')
       expect(namer.next.to_s).to eq('sitemap1.xml.gz')
     end
 
     it 'with a starting index' do
-      namer = SitemapGenerator::SimpleNamer.new(:sitemap, :zero => 'abc', :start => 10)
+      namer = described_class.new(:sitemap, zero: 'abc', start: 10)
       expect(namer.to_s).to eq('sitemapabc.xml.gz')
       expect(namer.next.to_s).to eq('sitemap10.xml.gz')
       expect(namer.next.to_s).to eq('sitemap11.xml.gz')

--- a/spec/sitemap_generator/sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemap_spec.rb
@@ -1,37 +1,40 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::Sitemap do
-  subject { described_class }
+  subject(:sitemap) { described_class }
 
-  it "has a class name" do
-    expect(subject.class.name).to match "SitemapGenerator::"
+  it 'has a class name' do
+    expect(sitemap.class.name).to match 'SitemapGenerator::'
   end
 
-  describe "method missing" do
-    it "should not be public" do
-      expect(subject.methods).to_not include :method_missing
+  describe 'method missing' do
+    it 'is not public' do
+      expect(sitemap.methods).not_to include :method_missing
     end
 
-    it "responds properly" do
-      expect(subject.method :default_host).to be_a Method
+    it 'responds properly' do
+      expect(sitemap.method(:default_host)).to be_a Method
     end
 
-    it "respects inheritance" do
-      subject.class.include Module.new {
-        def method_missing(*args)
+    it 'respects inheritance' do
+      sitemap.class.include(Module.new do
+        def method_missing(*_args)
           :inherited
         end
+
         def respond_to_missing?(name, *)
           name == :something_inherited
         end
-      }
+      end)
 
-      expect(subject).to respond_to :something_inherited
-      expect(subject.linkset_doesnt_know).to be :inherited
+      expect(sitemap).to respond_to :something_inherited
+      expect(sitemap.linkset_doesnt_know).to be :inherited
     end
 
-    it "unconventionally delegates private (and protected) methods" do
-      expect { subject.options_for_group({}) }.to_not raise_error
+    it 'unconventionally delegates private (and protected) methods' do
+      expect { sitemap.options_for_group({}) }.not_to raise_error
     end
   end
 end

--- a/spec/sitemap_generator/sitemaps/alternate_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/alternate_sitemap_spec.rb
@@ -1,16 +1,17 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator' do
-  it 'should not include media element unless provided' do
+  it 'does not include media element unless provided' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternates => [
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html'
-        }
-      ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 lang: 'de',
+                                                                 href: 'http://www.example.de/link_with_alternate.html'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -24,15 +25,14 @@ RSpec.describe 'SitemapGenerator' do
     expect(alternate.attribute('media')).to be_nil
   end
 
-  it 'should not include hreflang element unless provided' do
+  it 'does not include hreflang element unless provided' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-                                                             :host => 'http://www.example.com',
-                                                             :alternates => [
-                                                                 {
-                                                                     :href => 'http://www.example.de/link_with_alternate.html'
-                                                                 }
-                                                             ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 href: 'http://www.example.de/link_with_alternate.html'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -45,17 +45,16 @@ RSpec.describe 'SitemapGenerator' do
     expect(alternate.attribute('hreflang')).to be_nil
   end
 
-  it 'should add alternate links to sitemap' do
+  it 'adds alternate links to sitemap' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternates => [
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html',
-          :media => 'only screen and (max-width: 640px)'
-        }
-      ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 lang: 'de',
+                                                                 href: 'http://www.example.de/link_with_alternate.html',
+                                                                 media: 'only screen and (max-width: 640px)'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -70,18 +69,17 @@ RSpec.describe 'SitemapGenerator' do
     expect(alternate.attribute('media').value).to eq('only screen and (max-width: 640px)')
   end
 
-  it 'should add alternate links to sitemap with rel nofollow' do
+  it 'adds alternate links to sitemap with rel nofollow' do
     xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('link_with_alternates.html',
-      :host => 'http://www.example.com',
-      :alternates => [
-        {
-          :lang => 'de',
-          :href => 'http://www.example.de/link_with_alternate.html',
-          :nofollow => true,
-          :media => 'only screen and (max-width: 640px)'
-        }
-      ]
-    ).to_xml
+                                                             host: 'http://www.example.com',
+                                                             alternates: [
+                                                               {
+                                                                 lang: 'de',
+                                                                 href: 'http://www.example.de/link_with_alternate.html',
+                                                                 nofollow: true,
+                                                                 media: 'only screen and (max-width: 640px)'
+                                                               }
+                                                             ]).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns='http://www.sitemaps.org/schemas/sitemap/0.9' xmlns:xhtml='http://www.w3.org/1999/xhtml'>#{xml_fragment}</root>")
     url = doc.css('url')
@@ -95,6 +93,4 @@ RSpec.describe 'SitemapGenerator' do
     expect(alternate.attribute('href').value).to eq('http://www.example.de/link_with_alternate.html')
     expect(alternate.attribute('media').value).to eq('only screen and (max-width: 640px)')
   end
-
 end
-

--- a/spec/sitemap_generator/sitemaps/mobile_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/mobile_sitemap_spec.rb
@@ -1,14 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator' do
-
-  it 'should add the mobile sitemap element' do
+  it 'adds the mobile sitemap element' do
     loc = 'http://www.example.com/mobile_page.html'
 
     mobile_xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('mobile_page.html',
-      :host => 'http://www.example.com',
-      :mobile => true
-    ).to_xml
+                                                                    host: 'http://www.example.com',
+                                                                    mobile: true).to_xml
 
     # Check that the options were parsed correctly
     doc = Nokogiri::XML.parse("<root xmlns:mobile='#{SitemapGenerator::SCHEMAS['mobile']}'>#{mobile_xml_fragment}</root>")

--- a/spec/sitemap_generator/sitemaps/news_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/news_sitemap_spec.rb
@@ -1,24 +1,23 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator' do
-
-  it 'should add the news sitemap element' do
-    loc = 'http://www.example.com/my_article.html'
-
+  it 'adds the news sitemap element' do
     news_xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('my_article.html', {
-      :host => 'http://www.example.com',
+                                                                    host: 'http://www.example.com',
 
-      :news => {
-        :publication_name => 'Example',
-        :publication_language => 'en',
-        :title => 'My Article',
-        :keywords => 'my article, articles about myself',
-        :stock_tickers => 'SAO:PETR3',
-        :publication_date => '2011-08-22',
-        :access => 'Subscription',
-        :genres => 'PressRelease'
-      }
-    }).to_xml
+                                                                    news: {
+                                                                      publication_name: 'Example',
+                                                                      publication_language: 'en',
+                                                                      title: 'My Article',
+                                                                      keywords: 'my article, articles about myself',
+                                                                      stock_tickers: 'SAO:PETR3',
+                                                                      publication_date: '2011-08-22',
+                                                                      access: 'Subscription',
+                                                                      genres: 'PressRelease'
+                                                                    }
+                                                                  }).to_xml
 
     doc = Nokogiri::XML.parse("<root xmlns:news='#{SitemapGenerator::SCHEMAS['news']}'>#{news_xml_fragment}</root>")
 

--- a/spec/sitemap_generator/sitemaps/no_block_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/no_block_sitemap_spec.rb
@@ -1,21 +1,24 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator' do
+  it 'generates sitemaps without blocks' do
+    expect do
+      sitemap = SitemapGenerator::Sitemap.create(default_host: 'http://www.example.com', compress: false)
 
-  it 'should generate sitemaps without blocks' do
-    sitemap = SitemapGenerator::Sitemap.create(default_host: 'http://www.example.com', compress: false)
+      sitemap.add('/home')
 
-    sitemap.add('/home')
+      blog_group = sitemap.group(filename: :blog, default_host: 'http://example.com/blog')
+      blog_group.add('post1')
+      blog_group.finalize!
 
-    blog_group = sitemap.group(filename: :blog, default_host: 'http://example.com/blog')
-    blog_group.add('post1')
-    blog_group.finalize!
+      news_group = sitemap.group(filename: :news, default_host: 'http://example.com/news')
+      news_group.add('news1')
+      news_group.add('news2')
+      news_group.finalize!
 
-    news_group = sitemap.group(filename: :news, default_host: 'http://example.com/news')
-    news_group.add('news1')
-    news_group.add('news2')
-    news_group.finalize!
-
-    sitemap.finalize!
+      sitemap.finalize!
+    end.not_to raise_error
   end
 end

--- a/spec/sitemap_generator/sitemaps/pagemap_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/pagemap_sitemap_spec.rb
@@ -1,32 +1,34 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator' do
   let(:schema) { SitemapGenerator::SCHEMAS['pagemap'] }
 
-  it 'should add the pagemap sitemap element' do
+  it 'adds the pagemap sitemap element' do
     pagemap_xml_fragment = SitemapGenerator::Builder::SitemapUrl.new('my_page.html', {
-      :host => 'http://www.example.com',
+                                                                       host: 'http://www.example.com',
 
-      :pagemap => {
-        :dataobjects => [
-          {
-            :type => 'document',
-            :id => 'hibachi',
-            :attributes => [
-              {:name => 'name', :value => 'Dragon'},
-              {:name => 'review', :value => 3.5},
-            ]
-          },
-          {
-            :type => 'stats',
-            :attributes => [
-              {:name => 'installs', :value => 2000},
-              {:name => 'comments', :value => 200},
-            ]
-          }
-        ]
-      }
-    }).to_xml
+                                                                       pagemap: {
+                                                                         dataobjects: [
+                                                                           {
+                                                                             type: 'document',
+                                                                             id: 'hibachi',
+                                                                             attributes: [
+                                                                               { name: 'name', value: 'Dragon' },
+                                                                               { name: 'review', value: 3.5 }
+                                                                             ]
+                                                                           },
+                                                                           {
+                                                                             type: 'stats',
+                                                                             attributes: [
+                                                                               { name: 'installs', value: 2000 },
+                                                                               { name: 'comments', value: 200 }
+                                                                             ]
+                                                                           }
+                                                                         ]
+                                                                       }
+                                                                     }).to_xml
 
     # Nokogiri is a fickle beast.  We have to add the namespace and define
     # the prefix in order for XPath queries to work.  And then we have to
@@ -39,7 +41,7 @@ RSpec.describe 'SitemapGenerator' do
     loc = url.at_xpath('loc')
     expect(loc.text).to eq('http://www.example.com/my_page.html')
 
-    pagemap =  doc.at_xpath('//pagemap:PageMap', 'pagemap' => schema)
+    pagemap = doc.at_xpath('//pagemap:PageMap', 'pagemap' => schema)
     expect(pagemap.element_children.count).to eq(2)
     dataobject = pagemap.at_xpath('//pagemap:DataObject')
     expect(dataobject.attributes['type'].value).to eq('document')

--- a/spec/sitemap_generator/sitemaps/video_sitemap_spec.rb
+++ b/spec/sitemap_generator/sitemaps/video_sitemap_spec.rb
@@ -1,47 +1,49 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SitemapGenerator' do
   let(:url_options) do
     {
-      :host => 'http://example.com',
-      :path => 'cool_video.html'
+      host: 'http://example.com',
+      path: 'cool_video.html'
     }
   end
 
   let(:video_options) do
     {
-      :thumbnail_loc => 'http://example.com/video1_thumbnail.png',
-      :title => 'Cool Video',
-      :content_loc => 'http://example.com/cool_video.mpg',
-      :player_loc => 'http://example.com/cool_video_player.swf',
-      :gallery_loc => 'http://example.com/cool_video_gallery',
-      :gallery_title => 'Gallery Title',
-      :allow_embed => true,
-      :autoplay => 'id=123',
-      :description => 'An new perspective in cool video technology',
-      :tags => %w(tag1 tag2 tag3),
-      :category => 'cat1',
-      :uploader => 'sokrates',
-      :uploader_info => 'http://sokrates.example.com',
-      :expiration_date => Time.at(0),
-      :publication_date => Time.at(0),
-      :family_friendly => true,
-      :view_count => 123,
-      :duration => 456,
-      :rating => 0.499999999,
-      :price => 123.45,
-      :price_currency => 'CAD',
-      :price_resolution => 'HD',
-      :price_type => 'rent'
+      thumbnail_loc: 'http://example.com/video1_thumbnail.png',
+      title: 'Cool Video',
+      content_loc: 'http://example.com/cool_video.mpg',
+      player_loc: 'http://example.com/cool_video_player.swf',
+      gallery_loc: 'http://example.com/cool_video_gallery',
+      gallery_title: 'Gallery Title',
+      allow_embed: true,
+      autoplay: 'id=123',
+      description: 'An new perspective in cool video technology',
+      tags: %w[tag1 tag2 tag3],
+      category: 'cat1',
+      uploader: 'sokrates',
+      uploader_info: 'http://sokrates.example.com',
+      expiration_date: Time.at(0),
+      publication_date: Time.at(0),
+      family_friendly: true,
+      view_count: 123,
+      duration: 456,
+      rating: 0.499999999,
+      price: 123.45,
+      price_currency: 'CAD',
+      price_resolution: 'HD',
+      price_type: 'rent'
     }
   end
 
   # Return XML for the <URL> element.
   def video_xml(video_options)
     SitemapGenerator::Builder::SitemapUrl.new(url_options[:path], {
-      :host => url_options[:host],
-      :video => video_options
-    }).to_xml
+                                                host: url_options[:host],
+                                                video: video_options
+                                              }).to_xml
   end
 
   # Return a Nokogiri document from the XML.  The root of the document is the <URL> element.
@@ -58,16 +60,17 @@ RSpec.describe 'SitemapGenerator' do
     expect(video_doc.at_xpath('video:title').text).to         eq(video_options[:title])
     expect(video_doc.at_xpath('video:view_count').text).to    eq(video_options[:view_count].to_s)
     expect(video_doc.at_xpath('video:duration').text).to      eq(video_options[:duration].to_s)
-    expect(video_doc.at_xpath('video:rating').text).to        eq('%0.1f' % video_options[:rating])
+    expect(video_doc.at_xpath('video:rating').text).to eq(format('%0.1f', video_options[:rating]))
     expect(video_doc.at_xpath('video:content_loc').text).to   eq(video_options[:content_loc])
     expect(video_doc.at_xpath('video:category').text).to      eq(video_options[:category])
     expect(video_doc.xpath('video:tag').collect(&:text)).to   eq(video_options[:tags])
     expect(video_doc.at_xpath('video:expiration_date').text).to  eq(video_options[:expiration_date].iso8601)
     expect(video_doc.at_xpath('video:publication_date').text).to eq(video_options[:publication_date].iso8601)
-    expect(video_doc.at_xpath('video:player_loc').text).to    eq(video_options[:player_loc])
-    expect(video_doc.at_xpath('video:player_loc').attribute('allow_embed').text).to eq(video_options[:allow_embed] ? 'yes' : 'no')
+    expect(video_doc.at_xpath('video:player_loc').text).to eq(video_options[:player_loc])
+    expected_allow_embed = video_options[:allow_embed] ? 'yes' : 'no'
+    expect(video_doc.at_xpath('video:player_loc').attribute('allow_embed').text).to eq(expected_allow_embed)
     expect(video_doc.at_xpath('video:player_loc').attribute('autoplay').text).to    eq(video_options[:autoplay])
-    expect(video_doc.at_xpath('video:uploader').text).to      eq(video_options[:uploader])
+    expect(video_doc.at_xpath('video:uploader').text).to eq(video_options[:uploader])
     expect(video_doc.at_xpath('video:uploader').attribute('info').text).to eq(video_options[:uploader_info])
     expect(video_doc.at_xpath('video:price').text).to eq(video_options[:price].to_s)
     expect(video_doc.at_xpath('video:price').attribute('resolution').text).to eq(video_options[:price_resolution].to_s)
@@ -76,14 +79,14 @@ RSpec.describe 'SitemapGenerator' do
     xml_fragment_should_validate_against_schema(video_doc, 'sitemap-video', 'xmlns:video' => SitemapGenerator::SCHEMAS['video'])
   end
 
-  it 'should add a valid video sitemap element' do
+  it 'adds a valid video sitemap element' do
     xml = video_xml(video_options)
     doc = video_doc(xml)
     expect(doc.at_xpath('//url/loc').text).to eq(File.join(url_options[:host], url_options[:path]))
     validate_video_element(doc.at_xpath('//url/video:video'), video_options)
   end
 
-  it 'should support multiple video elements' do
+  it 'supports multiple video elements' do
     xml = video_xml([video_options, video_options])
     doc = video_doc(xml)
     expect(doc.at_xpath('//url/loc').text).to eq(File.join(url_options[:host], url_options[:path]))
@@ -93,15 +96,16 @@ RSpec.describe 'SitemapGenerator' do
     end
   end
 
-  it 'should default allow_embed to \'yes\'' do
-    xml = video_xml(video_options.merge(:allow_embed => nil))
+  it "defaults allow_embed to 'yes'" do
+    xml = video_xml(video_options.merge(allow_embed: nil))
     doc = video_doc(xml)
     expect(doc.at_xpath('//url/video:video/video:player_loc').attribute('allow_embed').text).to eq('yes')
   end
 
-  it 'should not include optional elements if they are not passed' do
-    optional = [:player_loc, :content_loc, :category, :tags, :tag, :uploader, :gallery_loc, :family_friendly, :publication_date, :expiration_date, :view_count, :rating, :duration]
-    required_options = video_options.delete_if { |k,v| optional.include?(k) }
+  it 'does not include optional elements if they are not passed' do
+    optional = %i[player_loc content_loc category tags tag uploader gallery_loc family_friendly
+                  publication_date expiration_date view_count rating duration]
+    required_options = video_options.delete_if { |k, _v| optional.include?(k) }
     xml = video_xml(required_options)
     doc = video_doc(xml)
     optional.each do |element|
@@ -109,8 +113,8 @@ RSpec.describe 'SitemapGenerator' do
     end
   end
 
-  it 'should not include autoplay param if blank' do
-    xml = video_xml(video_options.tap {|v| v.delete(:autoplay) })
+  it 'does not include autoplay param if blank' do
+    xml = video_xml(video_options.tap { |v| v.delete(:autoplay) })
     doc = video_doc(xml)
     expect(doc.at_xpath('//url/video:video/video:player_loc').attribute('autoplay')).to be_nil
   end

--- a/spec/sitemap_generator/tasks_spec.rb
+++ b/spec/sitemap_generator/tasks_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe 'Rake Tasks' do
       before do
         SitemapGenerator::Sitemap.verbose = false
         allow(Rake).to receive(:verbose).and_return(true)
-        allow(SitemapGenerator::Interpreter).to receive(:run)
       end
 
       after do
@@ -24,8 +23,8 @@ RSpec.describe 'Rake Tasks' do
       end
 
       it 'does not pass verbose: to Interpreter.run' do
+        expect(SitemapGenerator::Interpreter).to receive(:run).with(hash_excluding(:verbose))
         Rake::Task['sitemap:create'].execute
-        expect(SitemapGenerator::Interpreter).to have_received(:run).with(hash_excluding(:verbose))
       end
     end
   end

--- a/spec/sitemap_generator/templates_spec.rb
+++ b/spec/sitemap_generator/templates_spec.rb
@@ -1,21 +1,23 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-RSpec.describe 'Templates class' do
-
-  it 'should provide method access to each template' do
+RSpec.describe SitemapGenerator::Templates do
+  it 'provides method access to each template' do
     SitemapGenerator::Templates::FILES.each do |name, file|
-      expect(SitemapGenerator.templates.send(name)).not_to be(nil)
-      expect(SitemapGenerator.templates.send(name)).to eq(File.read(File.join(SitemapGenerator.root, 'templates', file)))
+      expect(SitemapGenerator.templates.send(name)).not_to be_nil
+      expect(SitemapGenerator.templates.send(name)).to eq(File.read(File.join(SitemapGenerator.root, 'templates',
+                                                                              file)))
     end
   end
 
   describe 'templates' do
     before do
       SitemapGenerator.templates.sitemap_sample = nil
-      expect(File).to receive(:read).and_return('read file').once
     end
 
-    it 'should only be read once' do
+    it 'reads the template file only once' do
+      expect(File).to receive(:read).and_return('read file').once
       SitemapGenerator.templates.sitemap_sample
       SitemapGenerator.templates.sitemap_sample
     end

--- a/spec/sitemap_generator/utilities/existence_spec.rb
+++ b/spec/sitemap_generator/utilities/existence_spec.rb
@@ -1,25 +1,31 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 class EmptyTrue
-  def empty?() true; end
+  def empty?
+    true
+  end
 end
 
 class EmptyFalse
-  def empty?() false; end
+  def empty?
+    false
+  end
 end
 
-BLANK = [ EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", [], {} ]
-NOT   = [ EmptyFalse.new, Object.new, true, 0, 1, 'a', [nil], { nil => 0 } ]
+BLANK = [EmptyTrue.new, nil, false, '', '   ', "  \n\t  \r ", [], {}].freeze
+NOT   = [EmptyFalse.new, Object.new, true, 0, 1, 'a', [nil], { nil => 0 }].freeze
 
 RSpec.describe Object do
   let(:utils) { SitemapGenerator::Utilities }
 
-  it 'should define blankness' do
+  it 'defines blankness' do
     BLANK.each { |v| expect(utils.blank?(v)).to be(true) }
     NOT.each   { |v| expect(utils.blank?(v)).to be(false) }
   end
 
-  it 'should define presence' do
+  it 'defines presence' do
     BLANK.each { |v| expect(utils.present?(v)).to be(false) }
     NOT.each   { |v| expect(utils.present?(v)).to be(true) }
   end

--- a/spec/sitemap_generator/utilities/hash_spec.rb
+++ b/spec/sitemap_generator/utilities/hash_spec.rb
@@ -34,24 +34,24 @@ RSpec.describe SitemapGenerator::Utilities do
                          end
     end
 
-    it 'symbolize_keyses' do
+    it 'symbolizes keys' do
       expect(utils.symbolize_keys(@symbols)).to eq(@symbols)
       expect(utils.symbolize_keys(@strings)).to eq(@symbols)
       expect(utils.symbolize_keys(@mixed)).to eq(@symbols)
     end
 
-    it 'symbolize_keys!s' do
+    it 'symbolizes keys destructively' do
       expect(utils.symbolize_keys!(@symbols.dup)).to eq(@symbols)
       expect(utils.symbolize_keys!(@strings.dup)).to eq(@symbols)
       expect(utils.symbolize_keys!(@mixed.dup)).to eq(@symbols)
     end
 
-    it 'symbolize_keys_preserves_keys_that_cant_be_symbolizeds' do
+    it 'preserves keys that cannot be symbolized' do
       expect(utils.symbolize_keys(@illegal_symbols)).to eq(@illegal_symbols)
       expect(utils.symbolize_keys!(@illegal_symbols.dup)).to eq(@illegal_symbols)
     end
 
-    it 'symbolize_keys_preserves_fixnum_keyses' do
+    it 'preserves fixnum keys' do
       expect(utils.symbolize_keys(@fixnums)).to eq(@fixnums)
       expect(utils.symbolize_keys!(@fixnums.dup)).to eq(@fixnums)
     end

--- a/spec/sitemap_generator/utilities/hash_spec.rb
+++ b/spec/sitemap_generator/utilities/hash_spec.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::Utilities do
-  let(:utils) { SitemapGenerator::Utilities }
+  let(:utils) { described_class }
 
   describe 'assert_valid_keys' do
-    it 'should raise' do
+    it 'raises' do
       expect do
-        utils.assert_valid_keys({ :failore => 'stuff', :funny => 'business' }, [ :failure, :funny])
-        utils.assert_valid_keys({ :failore => 'stuff', :funny => 'business' }, :failure, :funny)
+        utils.assert_valid_keys({ failore: 'stuff', funny: 'business' }, %i[failure funny])
+        utils.assert_valid_keys({ failore: 'stuff', funny: 'business' }, :failure, :funny)
       end.to raise_error(ArgumentError, 'Unknown key(s): failore')
     end
 
-    it 'should not raise' do
+    it 'does not raise' do
       expect do
-        utils.assert_valid_keys({ :failure => 'stuff', :funny => 'business' }, [ :failure, :funny ])
-        utils.assert_valid_keys({ :failure => 'stuff', :funny => 'business' }, :failure, :funny)
+        utils.assert_valid_keys({ failure: 'stuff', funny: 'business' }, %i[failure funny])
+        utils.assert_valid_keys({ failure: 'stuff', funny: 'business' }, :failure, :funny)
       end.not_to raise_error
     end
   end
@@ -22,34 +24,34 @@ RSpec.describe SitemapGenerator::Utilities do
   describe 'keys' do
     before do
       @strings = { 'a' => 1, 'b' => 2 }
-      @symbols = { :a  => 1, :b  => 2 }
-      @mixed   = { :a  => 1, 'b' => 2 }
-      @fixnums = {  0  => 1,  1  => 2 }
-      if RUBY_VERSION < '1.9.0'
-        @illegal_symbols = { '\0' => 1, '' => 2, [] => 3 }
-      else
-        @illegal_symbols = { [] => 3 }
-      end
+      @symbols = { a: 1, b: 2 }
+      @mixed   = { :a => 1, 'b' => 2 }
+      @fixnums = { 0 => 1, 1 => 2 }
+      @illegal_symbols = if RUBY_VERSION < '1.9.0'
+                           { '\0' => 1, '' => 2, [] => 3 }
+                         else
+                           { [] => 3 }
+                         end
     end
 
-    it 'should symbolize_keys' do
+    it 'symbolize_keyses' do
       expect(utils.symbolize_keys(@symbols)).to eq(@symbols)
       expect(utils.symbolize_keys(@strings)).to eq(@symbols)
       expect(utils.symbolize_keys(@mixed)).to eq(@symbols)
     end
 
-    it 'should symbolize_keys!' do
+    it 'symbolize_keys!s' do
       expect(utils.symbolize_keys!(@symbols.dup)).to eq(@symbols)
       expect(utils.symbolize_keys!(@strings.dup)).to eq(@symbols)
       expect(utils.symbolize_keys!(@mixed.dup)).to eq(@symbols)
     end
 
-    it 'should symbolize_keys_preserves_keys_that_cant_be_symbolized' do
+    it 'symbolize_keys_preserves_keys_that_cant_be_symbolizeds' do
       expect(utils.symbolize_keys(@illegal_symbols)).to eq(@illegal_symbols)
       expect(utils.symbolize_keys!(@illegal_symbols.dup)).to eq(@illegal_symbols)
     end
 
-    it 'should symbolize_keys_preserves_fixnum_keys' do
+    it 'symbolize_keys_preserves_fixnum_keyses' do
       expect(utils.symbolize_keys(@fixnums)).to eq(@fixnums)
       expect(utils.symbolize_keys!(@fixnums.dup)).to eq(@fixnums)
     end

--- a/spec/sitemap_generator/utilities/rounding_spec.rb
+++ b/spec/sitemap_generator/utilities/rounding_spec.rb
@@ -1,31 +1,33 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe SitemapGenerator::Utilities do
   describe 'rounding' do
-    let(:utils) { SitemapGenerator::Utilities }
+    let(:utils) { described_class }
 
-    it 'should round for positive number' do
-      expect(utils.round(1.4))      .to eq(1)
-      expect(utils.round(1.6))     .to eq(2)
-      expect(utils.round(1.6, 0))  .to eq(2)
-      expect(utils.round(1.4, 1))  .to eq(1.4)
-      expect(utils.round(1.4, 3))  .to eq(1.4)
-      expect(utils.round(1.45, 1)) .to eq(1.5)
+    it 'rounds for positive number' do
+      expect(utils.round(1.4)).to eq(1)
+      expect(utils.round(1.6)).to eq(2)
+      expect(utils.round(1.6, 0)).to eq(2)
+      expect(utils.round(1.4, 1)).to eq(1.4)
+      expect(utils.round(1.4, 3)).to eq(1.4)
+      expect(utils.round(1.45, 1)).to eq(1.5)
       expect(utils.round(1.445, 2)).to eq(1.45)
       # Demonstrates a bug in the round method
       # utils.round(9.995, 2).should == 10
     end
 
-    it 'should round for negative number' do
-      expect(utils.round(-1.4))    .to eq(-1)
-      expect(utils.round(-1.6))    .to eq(-2)
-      expect(utils.round(-1.4, 1)) .to eq(-1.4)
+    it 'rounds for negative number' do
+      expect(utils.round(-1.4)).to eq(-1)
+      expect(utils.round(-1.6)).to eq(-2)
+      expect(utils.round(-1.4, 1)).to eq(-1.4)
       expect(utils.round(-1.45, 1)).to eq(-1.5)
     end
 
-    it 'should round with negative precision' do
-      expect(utils.round(123456.0, -1)).to eq(123460.0)
-      expect(utils.round(123456.0, -2)).to eq(123500.0)
+    it 'rounds with negative precision' do
+      expect(utils.round(123_456.0, -1)).to eq(123_460.0)
+      expect(utils.round(123_456.0, -2)).to eq(123_500.0)
     end
   end
 end

--- a/spec/sitemap_generator/utilities_spec.rb
+++ b/spec/sitemap_generator/utilities_spec.rb
@@ -178,8 +178,7 @@ RSpec.describe SitemapGenerator::Utilities do
       let(:frozen) { Time.at(999_999).utc }
 
       before do
-        allow(Time).to receive(:zone).and_return(nil)
-        allow(Time).to receive(:now).and_return(frozen)
+        allow(Time).to receive_messages(zone: nil, now: frozen)
       end
 
       it 'returns Time.now' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load simplecov
 require 'simplecov'
 SimpleCov.start do

--- a/spec/support/file_macros.rb
+++ b/spec/support/file_macros.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module FileMacros
   def files_should_be_identical(first, second)
     expect(identical_files?(first, second)).to be(true)
@@ -8,26 +10,26 @@ module FileMacros
   end
 
   def file_should_exist(file)
-    expect(File.exist?(file)).to be(true), 'File #{file} should exist'
+    expect(File.exist?(file)).to be(true), "File #{file} should exist"
   end
 
   def directory_should_exist(dir)
-    expect(File.exist?(dir)).to be(true), 'Directory #{dir} should exist'
-    expect(File.directory?(dir)).to be(true), '#{dir} should be a directory'
+    expect(File.exist?(dir)).to be(true), "Directory #{dir} should exist"
+    expect(File.directory?(dir)).to be(true), "#{dir} should be a directory"
   end
 
   def directory_should_not_exist(dir)
-    expect(File.exist?(dir)).to be(false), 'Directory #{dir} should not exist'
+    expect(File.exist?(dir)).to be(false), "Directory #{dir} should not exist"
   end
 
   def file_should_not_exist(file)
-    expect(File.exist?(file)).to be(false), 'File #{file} should not exist'
+    expect(File.exist?(file)).to be(false), "File #{file} should not exist"
   end
 
   def identical_files?(first, second)
     file_should_exist(first)
     file_should_exist(second)
-    expect(open(second, 'r').read).to eq(open(first, 'r').read)
+    expect(File.read(second)).to eq(File.read(first))
   end
 
   def rails_path(file)
@@ -35,12 +37,13 @@ module FileMacros
   end
 
   def copy_sitemap_file_to_rails_app(extension)
-    FileUtils.cp(File.join(SitemapGenerator.root, "spec/files/sitemap.#{extension}.rb"), rails_path('config/sitemap.rb'))
+    FileUtils.cp(File.join(SitemapGenerator.root, "spec/files/sitemap.#{extension}.rb"),
+                 rails_path('config/sitemap.rb'))
   end
 
   def delete_sitemap_file_from_rails_app
     FileUtils.remove(rails_path('config/sitemap.rb'))
-  rescue
+  rescue StandardError
     nil
   end
 
@@ -49,7 +52,7 @@ module FileMacros
     FileUtils.mkdir_p(rails_path('public/'))
   end
 
-  def execute_sitemap_config(opts={})
-   SitemapGenerator::Interpreter.run(opts)
+  def execute_sitemap_config(opts = {})
+    SitemapGenerator::Interpreter.run(opts)
   end
 end

--- a/spec/support/sitemap_helpers.rb
+++ b/spec/support/sitemap_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SitemapHelpers
   def with_max_links(num)
     original = SitemapGenerator::Sitemap.max_sitemap_links

--- a/spec/support/xml_macros.rb
+++ b/spec/support/xml_macros.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module XmlMacros
   def gzipped_xml_file_should_validate_against_schema(xml_gz_filename, schema_name)
     Zlib::GzipReader.open(xml_gz_filename) do |xml_file|
@@ -10,7 +12,7 @@ module XmlMacros
   # `schema_name` gives the name of the schema file to validate against.  The schema
   # file is looked for in `spec/support/schemas/<schema_name>.xsd`.
   def xml_data_should_validate_against_schema(xml, schema_name)
-    xml = xml.is_a?(String) ? xml : xml.to_s
+    xml = xml.to_s unless xml.is_a?(String)
     doc = Nokogiri::XML(xml)
     schema_file = File.join(File.dirname(__FILE__), 'schemas', "#{schema_name}.xsd")
     schema = Nokogiri::XML::Schema File.read(schema_file)
@@ -40,8 +42,8 @@ module XmlMacros
   #   This validates the given XML using the spec/support/schemas/sitemap-video.xsd`
   #   schema.  The XML namespace `xmlns:video='http://www.google.com/schemas/sitemap-video/1.1'` is automatically
   #   added to the root element for you.
-  def xml_fragment_should_validate_against_schema(xml, schema_name, xmlns={})
-    xml = xml.is_a?(String) ? xml : xml.to_s
+  def xml_fragment_should_validate_against_schema(xml, schema_name, xmlns = {})
+    xml = xml.to_s unless xml.is_a?(String)
     doc = Nokogiri::XML(xml)
     doc.root.send(:[]=, *xmlns.first)
     xml_data_should_validate_against_schema(doc, schema_name)


### PR DESCRIPTION
This PR enables RuboCop on the spec test suite (`spec/**/*` and `integration/spec/**/*` were previously fully excluded), which caught several previously-invisible bugs — including tests with zero assertions that always passed regardless of behavior, and a NameError-in-waiting from a mismatched block parameter.

- Removes `spec/**/*` and `integration/spec/**/*` from `AllCops.Exclude`
- Autocorrects ~1,300 mechanical offenses (hash syntax, RSpec example wording, etc.)
- Configures `RSpec/NoExpectationExample`'s `AllowedPatterns` to recognize this suite's `*_should_*` helper naming convention instead of disabling the cop
- Disables/relaxes cops that conflict with established, systemic test style (multi-assert examples, `expect().to receive` mocking, etc.), each tagged as deliberate follow-up work rather than a permanent exception
- Fixes real bugs the linting surfaced: two always-passing tests with no assertions, a latent NameError from a mismatched block param, and ~50 broken Pathname-vs-String path comparisons introduced by an unsafe string-concatenation autocorrect (caught by re-running the full test suite, not just RuboCop)

Co-Authored-By: Claude <noreply@anthropic.com>